### PR TITLE
adds an action hook at the end of the main admin page

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -18,4 +18,5 @@
 
 	<p class="howto"><?php printf( __( 'If you need help getting things working then check the FAQ by clicking on help in the top right hand corner of this page.', 'hmbkp' ), '<a href="mailto:support@hmn.md">support@hmn.md</a>' ); ?></p>
 
+	<?php do_action( 'hmbkp_main_page_end' ); ?>
 </div>


### PR DESCRIPTION
Allows premium addons to extend the main plugin page to add input fields for their license keys, by doing
`add_action( 'hmbkp_main_page_end', 'hmbkpp_do_add_settings_fields' );`
