### PR TITLE
add a method that returns the schedules without instantiating a new object 

### DIFF
--- a/admin/backups.php
+++ b/admin/backups.php
@@ -1,4 +1,4 @@
-<?php $schedules = new HMBKP_Schedules; ?>
+<?php $schedules = HMBKP_Schedules::get_instance(); ?>
 
 <div>
 

--- a/classes/schedules.php
+++ b/classes/schedules.php
@@ -13,12 +13,23 @@ class HMBKP_Schedules {
 	 */
 	private $schedules;
 
+	protected static $instance;
+
+	public static function get_instance(){
+
+		if( null === self::$instance ){
+			self::$instance = new self;
+		}
+
+		return self::$instance;
+	}
+
 	/**
 	 * Load the schedules from wp_options and store in $this->schedules
 	 *
 	 * @access public
 	 */
-	public function __construct() {
+	private function __construct() {
 
 		global $wpdb;
 

--- a/functions/core.php
+++ b/functions/core.php
@@ -26,7 +26,7 @@ function hmbkp_deactivate() {
 	// Remove the plugin data cache
 	delete_transient( 'hmbkp_plugin_data' );
 
-	$schedules = new HMBKP_Schedules;
+	$schedules = HMBKP_Schedules::get_instance();
 
 	// Clear schedule crons
 	foreach ( $schedules->get_schedules() as $schedule )
@@ -140,7 +140,7 @@ function hmbkp_update() {
 	// Update from 2.2.4
 	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( '2.2.5' , get_option( 'hmbkp_plugin_version' ), '>' ) ) {
 
-		$schedules = new HMBKP_Schedules;
+		$schedules = HMBKP_Schedules::get_instance();
 
 		// Loop through all schedules and re-set the reccurrence to include hmbkp_
 		foreach ( $schedules->get_schedules() as $schedule ) {
@@ -194,7 +194,7 @@ function hmbkp_update() {
  */
 function hmbkp_setup_default_schedules() {
 
-	$schedules = new HMBKP_Schedules;
+	$schedules = HMBKP_Schedules::get_instance();
 
 	if ( $schedules->get_schedules() )
 		return;


### PR DESCRIPTION
I think HMBKP_Schedules class should have a static get_instance method that returns the only instance of schedules, so a singleton pattern probably.
Right now I have to instantiate a new object to get the schedules.

Or make get_schedules static?
