### PR TITLE
in certain cases hmbkp_default_path can have incorrect value

### DIFF
--- a/functions/core.php
+++ b/functions/core.php
@@ -348,7 +348,12 @@ function hmbkp_path_default() {
 
 	$path = untrailingslashit( get_option( 'hmbkp_default_path' ) );
 
-	if ( empty( $path ) ) {
+	$content_dir = HM_Backup::conform_dir( trailingslashit( WP_CONTENT_DIR ) );
+
+	$pos = strpos( $path, $content_dir );
+
+	// no path set or current path doesn't match the database value
+	if ( empty( $path ) || ( false === $pos ) || ( 0 !== $pos ) ) {
 
 		$path = HM_Backup::conform_dir( trailingslashit( WP_CONTENT_DIR ) . 'backupwordpress-' . substr( HMBKP_SECURE_KEY, 0, 10 ) . '-backups' );
 


### PR DESCRIPTION
If the site home path is changed, the value of hmbkp_default_path will not contain the correct path, thus resulting in 404 errors when trying to download a backup file.

I traced this back to the `hmbkp_path_default` function in core.php
- [x] add extra check to see if it is still valid, otherwise update it

related: https://github.com/humanmade/backupwordpress/issues/298

I wonder if this is related to the recent outage that Hostgator experienced?
