### PR TITLE
Remove openbasedir check

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -80,22 +80,6 @@ if ( ! defined( 'WEEK_IN_SECONDS' ) )
 if ( ! defined( 'YEAR_IN_SECONDS' ) )
 	define( 'YEAR_IN_SECONDS',  365 * DAY_IN_SECONDS    );
 
-if ( defined( 'HMBKP_PATH' ) && HMBKP_PATH ) {
-
-	if ( strlen( ini_get( 'open_basedir' ) ) > 0 ) {
-
-		$dirs = explode( PATH_SEPARATOR, ini_get( 'open_basedir' ) );
-
-		if ( ! in_array( HMBKP_PATH, $dirs ) )
-			add_action( 'admin_notices', 'hmbkp_warning' );
-
-	}
-}
-
-function hmbkp_warning() {
-	echo '<div class="error"><p>' . __( 'It appears that the HMBKP_PATH constant value is incompatible with the open_basedir directive restrictions. Please fix this and try again', 'hmbkp' ) . '</p></div>';
-}
-
 // Load the admin menu
 require_once( HMBKP_PLUGIN_PATH . '/admin/menu.php' );
 require_once( HMBKP_PLUGIN_PATH . '/admin/actions.php' );


### PR DESCRIPTION
So, I think the warnings are generated for the user who reported this issue because of some edge case that isn't handled by the current checks.
I can't replicate these warnings locally ( thought I did...). 
