### PR TITLE
Correct escaping function for schedule status

### DIFF
--- a/functions/interface.php
+++ b/functions/interface.php
@@ -255,7 +255,7 @@ function hmbkp_schedule_actions( HMBKP_Scheduled_Backup $schedule ) {
 	// Start output buffering
 	ob_start(); ?>
 
-	<span class="hmbkp-status"><?php echo $schedule->get_status() ? esc_html( $schedule->get_status() ) : __( 'Starting Backup', 'hmbkp' ); ?> <a href="<?php echo esc_url( add_query_arg( array( 'action' => 'hmbkp_cancel', 'hmbkp_schedule_id' => $schedule->get_id() ), HMBKP_ADMIN_URL ) ); ?>"><?php _e( 'cancel', 'hmbkp' ); ?></a></span>
+	<span class="hmbkp-status"><?php echo $schedule->get_status() ? wp_kses_data( $schedule->get_status() ) : __( 'Starting Backup', 'hmbkp' ); ?> <a href="<?php echo esc_url( add_query_arg( array( 'action' => 'hmbkp_cancel', 'hmbkp_schedule_id' => $schedule->get_id() ), HMBKP_ADMIN_URL ) ); ?>"><?php _e( 'cancel', 'hmbkp' ); ?></a></span>
 
 	<div class="hmbkp-schedule-actions row-actions">
 


### PR DESCRIPTION
Currently we get this:

![screen shot 2013-09-26 at 18 59 17](https://f.cloud.github.com/assets/308507/1220071/51b3afb0-26d5-11e3-8412-8ee02b5d74e9.png)

When we should get this:

![screen shot 2013-09-26 at 18 59 42](https://f.cloud.github.com/assets/308507/1220075/5ed73716-26d5-11e3-8ac9-4a0740508da1.png)
