### PR TITLE
Improve the way destinations are displayed in the schedule sentence

### DIFF
--- a/admin/schedule.php
+++ b/admin/schedule.php
@@ -95,21 +95,27 @@ $email_msg = '';
 
 foreach ( HMBKP_Services::get_services( $schedule ) as $file => $service ) {
 
-	if ( 'Email' == $service->name ) {
-		$email_msg = $service->display();
-	} elseif ( $service->is_service_active() ) {
-		$services[] = $service->display();
-	}
+	if ( 'Email' == $service->name )
+		$email_msg = esc_html( $service->display() );
 
+	elseif ( $service->is_service_active() )
+		$services[] = esc_html( $service->display() );
 
 }
-?>
+
+if ( count( $services ) > 1 ) {
+
+	$services[count( $services ) -2] .= ' & ' . $services[count( $services ) -1];
+
+	array_pop( $services );
+
+} ?>
 
 <div class="hmbkp-schedule-sentence<?php if ( $schedule->get_status() ) { ?> hmbkp-running<?php } ?>">
 
 	<?php
 	if ( ! empty( $services ) )
-		printf( __( 'Backup my %1$s %2$s %3$s, %4$s. %5$s Send a copy of each backup to: %6$s', 'hmbkp' ), $filesize, '<span>' . $type . '</span>', $reoccurrence, $backup_to_keep, $email_msg, implode( ', ', array_filter( $services ) ) );
+		printf( __( 'Backup my %1$s %2$s %3$s, %4$s. %5$s Send a copy of each backup to %6$s.', 'hmbkp' ), $filesize, '<span>' . $type . '</span>', $reoccurrence, $backup_to_keep, $email_msg, implode( ', ', array_filter( $services ) ) );
 	else
 		printf( __( 'Backup my %1$s %2$s %3$s, %4$s. %5$s', 'hmbkp' ), $filesize, '<span>' . $type . '</span>', $reoccurrence, $backup_to_keep, $email_msg );
 	?>


### PR DESCRIPTION
Goes from this:

![screen shot 2013-09-26 at 19 26 11](https://f.cloud.github.com/assets/308507/1220319/4274ab4a-26d9-11e3-9068-83992f5b4d84.png)
![screen shot 2013-09-26 at 19 26 39](https://f.cloud.github.com/assets/308507/1220320/4464d3e4-26d9-11e3-9209-730d0e8c24e2.png)

To this:

![screen shot 2013-09-26 at 19 27 11](https://f.cloud.github.com/assets/308507/1220322/49e2af76-26d9-11e3-8844-10f2a4ecbc55.png)
![screen shot 2013-09-26 at 19 26 49](https://f.cloud.github.com/assets/308507/1220323/4ae98124-26d9-11e3-8238-459ee6ff9d2c.png)
