### PR TITLE
fix wrong file paths in uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -7,11 +7,11 @@ if ( ! defined( 'HMBKP_SCHEDULE_TIME' ) )
 	define( 'HMBKP_SCHEDULE_TIME', '11pm' );
 
 // Load the schedules
-require_once( HMBKP_PLUGIN_PATH . '/hm-backup/hm-backup.php' );
-require_once( HMBKP_PLUGIN_PATH . '/classes/services.php' );
-require_once( HMBKP_PLUGIN_PATH . '/classes/schedule.php' );
-require_once( HMBKP_PLUGIN_PATH . '/classes/schedules.php' );
-require_once( HMBKP_PLUGIN_PATH . '/functions/core.php' );
+require_once( HMBKP_PLUGIN_PATH . 'hm-backup/hm-backup.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-services.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-schedule.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-schedules.php' );
+require_once( HMBKP_PLUGIN_PATH . 'functions/core.php' );
 
 $schedules = HMBKP_Schedules::get_instance();
 


### PR DESCRIPTION
fixes an error on uninstall:

<pre>
Warning: require_once(/home/paulwp/spine.paulwp.com/wp-content/plugins/backupwordpress//classes/services.php) [function.require-once]: failed to open stream: No such file or directory in /home/paulwp/spine.paulwp.com/wp-content/plugins/backupwordpress/uninstall.php on line 11

Fatal error: require_once() [function.require]: Failed opening required '/home/paulwp/spine.paulwp.com/wp-content/plugins/backupwordpress//classes/services.php' (include_path='.:/usr/local/lib/php:/usr/local/php5/lib/pear') in /home/paulwp/spine.paulwp.com/wp-content/plugins/backupwordpress/uninstall.php on line 11
</pre>
