### PR TITLE
Remove hardcoded reference to page=backupwordpress in js

### DIFF
--- a/assets/hmbkp.js
+++ b/assets/hmbkp.js
@@ -245,7 +245,7 @@ jQuery( document ).ready( function( $ ) {
 
 					// Reload the page so we see changes
 					if ( isNewSchedule )
-						location.replace( '//' + location.host + location.pathname + '?page=backupwordpress&hmbkp_schedule_id=' + scheduleId );
+						location.replace( '//' + location.host + location.pathname + '?page=' + hmbkp.page_slug + '&hmbkp_schedule_id=' + scheduleId );
 
 					else
 						location.reload();

--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -169,6 +169,7 @@ function hmbkp_load_scripts() {
 			'hmbkp',
 			'hmbkp',
 			array(
+				'page_slug'    => HMBKP_PLUGIN_SLUG,
 				'nonce'         		=> wp_create_nonce( 'hmbkp_nonce' ),
 				'update'				=> __( 'Update', 'hmbkp' ),
 				'cancel'				=> __( 'Cancel', 'hmbkp' ),


### PR DESCRIPTION
`hmbkp.js:246`

```
location.replace( '//' + location.host + location.pathname  + '?page=backupwordpress&hmbkp_schedule_id=' + scheduleId );
```

This causes a permissions error on add schedule if `HMBKP_SLUG` isn't `backupwordpress`.
