### PR TITLE
Only hide download links when the backups directory isn't web accesible

### DIFF
--- a/functions/interface.php
+++ b/functions/interface.php
@@ -26,11 +26,11 @@ function hmbkp_get_backup_row( $file, HMBKP_Scheduled_Backup $schedule ) {
 		<td>
 
 			<?php if (  hmbkp_is_path_accessible( hmbkp_path() )  ) : ?>
-
 			<a href="<?php echo wp_nonce_url( admin_url( 'tools.php?page=' . HMBKP_PLUGIN_SLUG . '&amp;hmbkp_download_backup=' . $encoded_file . '&amp;hmbkp_schedule_id=' . $schedule->get_id() ), 'hmbkp-download_backup' ); ?>"><?php _e( 'Download', 'hmbkp' ); ?></a> |
+			<?php endif; ?>
+
 			<a href="<?php echo wp_nonce_url( admin_url( 'tools.php?page=' . HMBKP_PLUGIN_SLUG . '&amp;hmbkp_delete_backup=' . $encoded_file . '&amp;hmbkp_schedule_id=' . $schedule->get_id() ), 'hmbkp-delete_backup' ); ?>" class="delete-action"><?php _e( 'Delete', 'hmbkp' ); ?></a>
 
-			<?php endif; ?>
 		</td>
 
 	</tr>


### PR DESCRIPTION
Deleting backups will continue to work fine.

@pdewouters this was changed by you in b05975d975d8caadef74b73f5b5d100a5d75bdcb
