### PR TITLE
Use `wp_mkdir_p` instead of `mkdir`

### DIFF
--- a/classes/wp-cli.php
+++ b/classes/wp-cli.php
@@ -34,7 +34,7 @@ class BackUpCommand extends WP_CLI_Command {
 		if ( ! empty( $assoc_args['root'] ) )
 			$hm_backup->set_root( $assoc_args['root'] );
 
-		if ( ( ! is_dir( $hm_backup->get_path() ) && ( ! is_writable( dirname( $hm_backup->get_path() ) ) || ! mkdir( $hm_backup->get_path() ) ) ) || ! is_writable( $hm_backup->get_path() ) ) {
+		if ( ( ! is_dir( $hm_backup->get_path() ) && ( ! is_writable( dirname( $hm_backup->get_path() ) ) || ! wp_mkdir_p( $hm_backup->get_path() ) ) ) || ! is_writable( $hm_backup->get_path() ) ) {
 			WP_CLI::error( __( 'Invalid backup path', 'hmbkp' ) );
 			return false;
 		}

--- a/functions/core.php
+++ b/functions/core.php
@@ -314,7 +314,7 @@ function hmbkp_path() {
 
 	// Create the backups directory if it doesn't exist
 	if ( ! is_dir( $path ) && is_writable( dirname( $path ) ) )
-		mkdir( $path, 0755 );
+		wp_mkdir_p( $path );
 
 	// If the path has changed then cache it
 	if ( get_option( 'hmbkp_path' ) !== $path )
@@ -400,7 +400,7 @@ function hmbkp_path_move( $from, $to ) {
 
 	// Create the new directory if it doesn't exist
 	if ( is_writable( dirname( $to ) ) && ! is_dir( $to ) )
-		mkdir( $to, 0755 );
+		wp_mkdir_p( $to );
 
 	// Bail if we couldn't
 	if ( ! is_dir( $to ) || ! is_writable( $to ) )


### PR DESCRIPTION
Would be better to use this core function instead of the vanilla PHP mkdir function
