### PR TITLE
Catch 'invalid reoccurence' error and reset schedule type

### DIFF
--- a/admin/schedule.php
+++ b/admin/schedule.php
@@ -64,7 +64,7 @@ switch ( $schedule->get_reoccurrence() ) :
 	break;
 
 	default:
-		wp_die( 'Invalid reoccurence' );
+		$schedule->set_reoccurrence( 'manually' );
 
 endswitch;
 


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/494927/847090/f290e4ec-f431-11e2-89af-5072e95f0673.png)
- BackUpWordPress has been active in the past.
- BackUpWordPress currently inactive but WP Remote active.
- I updated BackUpWordPress to the latest version
- I activated BackUpWordPress & went to the page in the admin
- Default schedules have "Invalid Reoccurence" and cannot be deleted
- I can still create new schedules fine
