### PR TITLE
Argument is not an array

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -204,7 +204,7 @@ function hmbkp_load_intercom_script() {
 	}
 
 	foreach ( HMBKP_Services::get_services() as $file => $service )
-		array_merge( $info, call_user_func( array( $service, 'intercom_data' ) ) );
+		array_merge( $info, (array)call_user_func( array( $service, 'intercom_data' ) ) );
 
 	$current_user = wp_get_current_user();
 


### PR DESCRIPTION
`Warning: array_merge(): Argument #2 is not an array in /srv/www/backupwordpress.dev/content/plugins/backupwordpress/backupwordpress.php on line 207`
