### PR TITLE
Exclude cache data from WP Supercache

### DIFF
--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -935,7 +935,7 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 
 			if ( ( false !== $pos ) && ( $folder !== $default_path ) ) {
 
-				$found_folders[] = $folder;
+				$found_folders[] = trailingslashit( $folder );
 
 			}
 


### PR DESCRIPTION
WP Supercache leaves a couple of folders that can amount to quite a large size
/wp-content/cache/
/wp-content/cache/supercache/

We should exclude these by default
