### PR TITLE
Only use shell_exec if it's available

### DIFF
--- a/classes/class-requirements.php
+++ b/classes/class-requirements.php
@@ -251,6 +251,9 @@ class HMBKP_Requirement_PHP_User extends HMBKP_Requirement {
 	 */
 	protected function test() {
 
+		if ( ! HM_Backup::is_shell_exec_available() )
+			return;
+
 		return shell_exec( 'whoami' );
 
 	}


### PR DESCRIPTION
We should only be using `shell_exec` if it's available:

```
[21-Jan-2014 00:04:13 America/Chicago] PHP Warning: shell_exec() has been disabled for security reasons in /home/username/public_html/wp-content/plugins/backupwordpress/classes/class-requirements.php on line 254
```

We can use [`HM_Backup:: is_shell_exec_available()`](https://github.com/humanmade/hm-backup/blob/master/hm-backup.php#L175)
