### PR TITLE
Pass per schedule file sizes to intercom instead of complete site

### DIFF
--- a/classes/class-requirements.php
+++ b/classes/class-requirements.php
@@ -563,9 +563,13 @@ class HMBKP_Requirement_Calculated_Size extends HMBKP_Requirement {
 	 */
 	protected function test() {
 
-		$schedule = new HMBKP_Scheduled_Backup( 'support' );
+		$schedules = HMBKP_Schedules::get_instance();
 
-		return $schedule->get_formatted_file_size();
+		foreach ( $schedules->get_schedules() as $schedule )
+			if ( $schedule->is_filesize_cached() )
+				$backup_sizes[$schedule->get_id()] = $schedule->get_formatted_file_size();
+
+		return $backup_sizes;
 
 	}
 


### PR DESCRIPTION
In ['class-requirements.php'](https://github.com/humanmade/backupwordpress/blob/master/classes/class-requirements.php#L568) we instantiate a new `HMBKP_Scheduled_Backup` object so we can get the calculated size of the whole site (database and files). The issue with this is that the file size calculation happens at run-time and can be very slow.

Instead we should loop through the schedules, and only return the file size if `is_filesize_cached`.

This will have the added benefit that the file sizes reported to Intercom will actually map to what is included in the backups (the current way ignores excludes etc.).
