### PR TITLE
Make the from email filterable

### DIFF
--- a/classes/class-email.php
+++ b/classes/class-email.php
@@ -138,7 +138,7 @@ class HMBKP_Email_Service extends HMBKP_Service {
 			$download = add_query_arg( 'hmbkp_download', base64_encode( $file ), HMBKP_ADMIN_URL );
 			$domain   = parse_url( home_url(), PHP_URL_HOST ) . parse_url( home_url(), PHP_URL_PATH );
 
-			$headers  = 'From: BackUpWordPress <' . get_bloginfo( 'admin_email' ) . '>' . "\r\n";
+			$headers  = 'From: BackUpWordPress <' . apply_filters( 'hmbkp_from_email', get_bloginfo( 'admin_email' ) ) . '>' . "\r\n";
 
 			// The backup failed, send a message saying as much
 			if ( ! file_exists( $file ) && ( $errors = array_merge( $this->schedule->get_errors(), $this->schedule->get_warnings() ) ) ) {


### PR DESCRIPTION
Some hosts only allow emails to be sent from the same domain, we should make the from email address filterable so that users affected by this can change the email to something that will work.
