### PR TITLE
Pass PHP timeout setting to Intercom

### DIFF
--- a/classes/class-requirements.php
+++ b/classes/class-requirements.php
@@ -968,3 +968,17 @@ class HMBKP_Requirement_Site_Url extends HMBKP_Requirement {
 }
 
 HMBKP_Requirements::register( 'HMBKP_Requirement_Site_Url', 'Site' );
+
+class HMBKP_Requirement_Max_Exec extends HMBKP_Requirement {
+
+	var $name = 'Max execution time';
+
+	protected function test(){
+
+		return @ini_get( 'max_execution_time' );
+
+	}
+
+}
+
+HMBKP_Requirements::register( 'HMBKP_Requirement_Max_Exec', 'PHP' );


### PR DESCRIPTION
It would be useful to pass `max_execution_time` to intercom to support debugging peoples issues.

This can be got using `ini_get( 'max_execution_time' );`
