### PR TITLE
Don't allow the plugin to function if the root dir is unreadable.

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -22,16 +22,12 @@
 
 	<?php include_once( HMBKP_PLUGIN_PATH . '/admin/backups.php' ); ?>
 
-<?php else : ?>
-
-	<p><strong><?php _e( 'You need to fix the issues detailed above before BackUpWordPress can start.', 'hmbkp' ); ?></strong></p>
-
-<?php endif; ?>
-
 	<p class="howto"><?php printf( __( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory. %2$s', 'hmbkp' ), '<a href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">', '</a>' ); ?></p>
 
 	<p class="howto"><?php _e( 'If you need help getting things working then check the FAQ by clicking on help in the top right hand corner of this page.', 'hmbkp' ); ?></p>
 
 	<p class="howto"><strong><?php printf( __( 'Wish you could store your backups in a safer place? Our %1$spremium extensions%2$s enable automatic backups to Dropbox, FTP, Google Drive and more.', 'hmbkp' ), '<a href="http://bwp.hmn.md/?utm_source=wordpress-org&utm_medium=wp-admin&utm_campaign=freeplugin">', '</a>' ); ?></strong></p>
+
+<?php endif; ?>
 
 </div>

--- a/functions/core.php
+++ b/functions/core.php
@@ -445,6 +445,11 @@ function hmbkp_possible() {
 	if ( ! wp_is_writable( hmbkp_path() ) || ! is_dir( hmbkp_path() ) )
 		return false;
 
+	$test_backup = new HMBKP_Scheduled_Backup( 'test_backup' );
+
+	if ( ! is_readable( $test_backup->get_root() ) )
+		return false;
+
 	return true;
 }
 

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -124,6 +124,19 @@ function hmbkp_admin_notices() {
 
 	endif;
 
+	$test_backup = new HMBKP_Scheduled_Backup( 'test_backup' );
+
+	if ( ! is_readable( $test_backup->get_root() ) ) :
+
+		function hmbkp_backup_root_unreadable_notice() {
+			$test_backup = new HMBKP_Scheduled_Backup( 'test_backup' );
+			echo '<div id="hmbkp-warning" class="updated fade"><p><strong>' . __( 'BackUpWordPress has detected a problem.', 'hmbkp' ) . '</strong>' . sprintf( __( 'Your backup root path %s isn\'t readable.', 'hmbkp' ), '<code>' . $test_backup->get_root() . '</code>' ) . '</p></div>';
+		}
+
+		add_action( 'admin_notices', 'hmbkp_backup_root_unreadable_notice' );
+
+	endif;
+
 }
 
 add_action( 'admin_head', 'hmbkp_admin_notices' );


### PR DESCRIPTION
If the path returned by `HMBKP_Scheduled_Backup::get_root()` isn't readable then we should disable the plugin in the same way we disable the plugin if `HMBKP_Scheduled_Backup::get_path()` isn't writable.

This PR adds a check to `hmbkp_possible()` for if the root path is readable and if it isn't a warning message is shown and the plugin functionality is disabled.
