### PR TITLE
Function is deprecated : screen_icon

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -1,7 +1,5 @@
 <div class="wrap">
 
-	<?php screen_icon( HMBKP_PLUGIN_SLUG ); ?>
-
 	<h2>
 		<?php _e( 'Manage Backups', 'hmbkp' ); ?>
 
@@ -11,7 +9,7 @@
 
 		<?php } else { ?>
 
-		<a id="intercom-info" class="colorbox add-new-h2" href="<?php echo wp_nonce_url( add_query_arg( array( 'action' => 'load_enable_support' ), is_multisite() ? admin_url( 'admin-ajax.php' ) : network_admin_url( 'admin-ajax.php' ) ), 'hmbkp_nonce' ); ?>">Enable Support</a>
+		<a id="intercom-info" class="colorbox add-new-h2" href="<?php echo wp_nonce_url( add_query_arg( array( 'action' => 'load_enable_support' ), is_multisite() ? admin_url( 'admin-ajax.php' ) : network_admin_url( 'admin-ajax.php' ) ), 'hmbkp_nonce' ); ?>"><?php _e( 'Enable Support', 'hmbkp' ); ?></a>
 
 		<?php } ?>
 


### PR DESCRIPTION
As from 3.8, the `screen_icon()` function is deprecated and needs removing
