### PR TITLE
Prevent direct access to scripts and folder listings

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -1,5 +1,7 @@
 <?php
 
+defined( 'WPINC' ) or die;
+
 /**
  * Delete the backup and then redirect
  * back to the backups page

--- a/admin/backups.php
+++ b/admin/backups.php
@@ -1,4 +1,7 @@
-<?php $schedules = HMBKP_Schedules::get_instance(); ?>
+<?php
+defined( 'WPINC' ) or die;
+
+$schedules = HMBKP_Schedules::get_instance(); ?>
 
 <div>
 

--- a/admin/constants.php
+++ b/admin/constants.php
@@ -1,3 +1,5 @@
+<?php defined( 'WPINC' ) or die; ?>
+
 <div id="hmbkp-constants">
 
 	<p><?php printf( __( 'You can %1$s any of the following %2$s in your %3$s to control advanced settings. %4$s. Defined %5$s will be highlighted.', 'hmbkp' ), '<code>define</code>', '<code>' . __( 'Constants', 'hmbkp' ) . '</code>', '<code>wp-config.php</code>', '<a href="http://codex.wordpress.org/Editing_wp-config.php">' . __( 'The Codex can help', 'hmbkp' ) . '</a>', '<code>' . __( 'Constants', 'hmbkp' ) . '</code>' ); ?></p>

--- a/admin/enable-support.php
+++ b/admin/enable-support.php
@@ -1,4 +1,7 @@
-<?php require_once HMBKP_PLUGIN_PATH . 'classes/class-requirements.php'; ?>
+<?php
+defined( 'WPINC' ) or die;
+
+require_once HMBKP_PLUGIN_PATH . 'classes/class-requirements.php'; ?>
 
 <h2><?php _e( 'Enable BackUpWordPress Support', 'hmbkp' ); ?></h2>
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * Add the backups menu item

--- a/admin/page.php
+++ b/admin/page.php
@@ -1,3 +1,5 @@
+<?php defined( 'WPINC' ) or die; ?>
+
 <div class="wrap">
 
 	<?php screen_icon( HMBKP_PLUGIN_SLUG ); ?>

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -1,3 +1,5 @@
+<?php defined( 'WPINC' ) or die; ?>
+
 <form method="post" class="hmbkp-form">
 
     <input type="hidden" name="hmbkp_schedule_id" value="<?php echo esc_attr( $schedule->get_id() ); ?>" />

--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -1,3 +1,5 @@
+<?php defined( 'WPINC' ) or die; ?>
+
 <form method="post" class="hmbkp-form" novalidate data-schedule-action="<?php if ( isset( $is_new_schedule ) ) { ?>add<?php } else { ?>edit<?php } ?>">
 
 	<input type="hidden" name="hmbkp_schedule_id" value="<?php echo esc_attr( $schedule->get_id() ); ?>" />

--- a/admin/schedule.php
+++ b/admin/schedule.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 // Calculated filesize
 $filesize = $schedule->is_filesize_cached() || isset( $recalculate_filesize ) ? '<code title="' . __( 'Backups will be compressed and should be smaller than this.', 'hmbkp' ) . '">' . esc_attr( $schedule->get_formatted_file_size() ) . '</code>' : '<code class="calculating" title="' . __( 'this shouldn\'t take long&hellip;', 'hmbkp' ) . '">' . __( 'calculating the size of your site&hellip;', 'hmbkp' ) . '</code>';

--- a/admin/server-info.php
+++ b/admin/server-info.php
@@ -1,4 +1,7 @@
-<?php foreach( HMBKP_Requirements::get_requirement_groups() as $group ) : ?>
+<?php
+defined( 'WPINC' ) or die;
+
+foreach( HMBKP_Requirements::get_requirement_groups() as $group ) : ?>
 
 	<h3><?php echo ucwords( $group ); ?></h3>
 

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -27,6 +27,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+defined( 'WPINC' ) or die;
+
 if ( ! defined( 'HMBKP_PLUGIN_SLUG' ) )
 	define( 'HMBKP_PLUGIN_SLUG', basename( dirname( __FILE__ ) ) );
 

--- a/classes/class-email.php
+++ b/classes/class-email.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * Email notifications for backups

--- a/classes/class-requirements.php
+++ b/classes/class-requirements.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * A singleton to handle the registering, unregistering

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * Extend HM Backup with scheduling and backup file management

--- a/classes/class-schedules.php
+++ b/classes/class-schedules.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * A simple class for loading schedules

--- a/classes/class-services.php
+++ b/classes/class-services.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * An abstract service class, individual services should

--- a/classes/index.php
+++ b/classes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/classes/wp-cli.php
+++ b/classes/wp-cli.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * Implement backup command

--- a/functions/core.php
+++ b/functions/core.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * Setup the plugin defaults on activation

--- a/functions/index.php
+++ b/functions/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'WPINC' ) or die;
 
 /**
  * Displays a row in the manage backups table

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,4 +1,9 @@
 <?php
+if ( ! current_user_can( 'activate_plugins' ) )
+	return;
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) )
+	exit();
 
 if ( ! defined( 'HMBKP_PLUGIN_PATH' ) )
 	define( 'HMBKP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
This Pull Request addresses the following issues:
- Stop anyone from listing the plugin subfolders by adding an `index.php` file.
- Stop anyone from executing a script directly by checking if a WordPress admin constant is defined
