### PR TITLE
No longer possible to add multiple notification email

### DIFF
--- a/classes/class-email.php
+++ b/classes/class-email.php
@@ -107,19 +107,29 @@ class HMBKP_Email_Service extends HMBKP_Service {
 
 		if ( isset( $new_data['email'] ) ) {
 
-			if ( ! empty( $new_data['email'] ) )
-				foreach ( explode( ',', $new_data['email'] ) as $email )
-					if ( ! is_email( $email ) )
-						$errors['email'] = sprintf( __( '%s isn\'t a valid email',  'hmbkp' ), $email );
+			if ( ! empty( $new_data['email'] ) ) {
 
-					if ( ! empty( $errors['email'] ) )
+				foreach ( explode( ',', $new_data['email'] ) as $email ) {
+
+					$email = trim( $email );
+
+					if ( ! is_email( $email ) ) {
+						$errors['email'] = sprintf( __( '%s isn\'t a valid email',  'hmbkp' ), $email );
+					}
+
+					if ( ! empty( $errors['email'] ) ) {
 						$new_data['email'] = '';
+					}
 
 				}
 
-				return $errors;
-
 			}
+
+			return $errors;
+
+		}
+
+	}
 
 	/**
 	 * Get an array or validated email address's


### PR DESCRIPTION
You should be able to add multiple email addresses to the schedule, separated by comma's.

However for some reason the validation is currently failing.

![screen shot 2014-03-13 at 15 52 39](https://f.cloud.github.com/assets/308507/2411467/bc0ea1fa-aac7-11e3-9b58-c9181ffa786f.png)

Props to http://wordpress.org/support/view/plugin-reviews/backupwordpress
