### PR TITLE
Additional backup directories to exclude

### DIFF
--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -924,7 +924,7 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 			}
 		}
 
-		$backupwp_folders = $this->find_backup_folders( 'backwp-up-', $hmn_upload_dir['path'] );
+		$backupwp_folders = $this->find_backup_folders( 'backwpup-', $hmn_upload_dir['path'] );
 
 		if ( ! empty( $backupwp_folders ) ) {
 			foreach ( $backupwp_folders as $path ) {
@@ -937,9 +937,9 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 			'wponlinebckp'     => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'backups' ),
 			'duplicator'       => trailingslashit( ABSPATH ) . trailingslashit( 'wp-snapshots' ),
 			'backupbuddy'      => trailingslashit( $hmn_upload_dir['path'] ) . trailingslashit( 'backupbuddy_backups' ),
+			'pb_backupbuddy'   => trailingslashit( $hmn_upload_dir['path'] ) . trailingslashit( 'pb_backupbuddy' ),
 			'wpdbmanager'      => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'backup-db' ),
 			'supercache'       => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'cache' ),
-			'pb_backupbuddy'   => trailingslashit( $hmn_upload_dir['path'] ) . trailingslashit( 'pb_backupbuddy' ),
 		);
 
 		foreach ( $blacklisted as $key => $path ) {


### PR DESCRIPTION
BackUpBuddy also creates a temp folder which we should exclude. Additionally there are some BackupWP directories which should be excluded.

```
/wp-content/uploads/pb_backupbuddy
/wp-content/uploads/backwpup-2d77ac-temp
/wp-content/uploads/backwpup-2d77ac-logs
/wp-content/uploads/backwpup-2d77ac-backups
/wp-content/uploads/backupbuddy_temp
```
