### PR TITLE
Incoming support requests needs consolidating

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,6 @@ Assign the pull request to Paul de Wouters
 ## Translations ##
 
 Please don't submit pull requests for translations. All translations are managed via http://translate.hmn.md
-Please request access via email at hello@hmn.md, mentioning "glotpress access request" in the subject line.
+Please request access via email at 7f1l4qyq@incoming.intercom.io, mentioning "glotpress access request" in the subject line.
 
 Thank you for contributing!

--- a/admin/page.php
+++ b/admin/page.php
@@ -5,7 +5,7 @@
 
 		<?php if ( get_option( 'hmbkp_enable_support' ) ) { ?>
 
-		<a id="intercom" class="add-new-h2" href="mailto:support@hmn.md"><?php _e( 'Support', 'hmbkp' ); ?></a>
+		<a id="intercom" class="add-new-h2" href="mailto:7f1l4qyq@incoming.intercom.io"><?php _e( 'Support', 'hmbkp' ); ?></a>
 
 		<?php } else { ?>
 

--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -10,7 +10,7 @@ Author URI: http://hmn.md/
 */
 
 /*
-Copyright 2011 - 2014 Human Made Limited  (email : support@hmn.md)
+Copyright 2011 - 2014 Human Made Limited  (email : 7f1l4qyq@incoming.intercom.io)
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/classes/class-email.php
+++ b/classes/class-email.php
@@ -176,7 +176,7 @@ class HMBKP_Email_Service extends HMBKP_Service {
 
 				$subject = sprintf( __( 'Backup of %s Failed', 'hmbkp' ), $domain );
 
-				$message = sprintf( __( 'BackUpWordPress was unable to backup your site %1$s.', 'hmbkp' ) . "\n\n" . __( 'Here are the errors that we\'re encountered:', 'hmbkp' ) . "\n\n" . '%2$s' . "\n\n" . __( 'If the errors above look like Martian, forward this email to %3$s and we\'ll take a look', 'hmbkp' ) . "\n\n" . __( "Kind Regards,\nThe Apologetic BackUpWordPress Backup Emailing Robot", 'hmbkp' ), home_url(), $error_message, 'support@hmn.md' );
+				$message = sprintf( __( 'BackUpWordPress was unable to backup your site %1$s.', 'hmbkp' ) . "\n\n" . __( 'Here are the errors that we\'re encountered:', 'hmbkp' ) . "\n\n" . '%2$s' . "\n\n" . __( 'If the errors above look like Martian, forward this email to %3$s and we\'ll take a look', 'hmbkp' ) . "\n\n" . __( "Kind Regards,\nThe Apologetic BackUpWordPress Backup Emailing Robot", 'hmbkp' ), home_url(), $error_message, '7f1l4qyq@incoming.intercom.io' );
 
 				wp_mail( $this->get_email_address_array(), $subject, $message, $headers );
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ The BackUpWordPress plugin is hosted on GitHub, if you want to help out with dev
 
 = Translations =
 
-We'd also love help translating the plugin into more languages, if you can help then please contact support@hmn.md or visit http://translate.hmn.md/.
+We'd also love help translating the plugin into more languages, if you can help then please contact 7f1l4qyq@incoming.intercom.io or visit http://translate.hmn.md/.
 
 == Installation ==
 
@@ -97,7 +97,7 @@ General support questions should be posted in the <a href="http://wordpress.org/
 
 For development issues, feature requests or anybody wishing to help out with development checkout <a href="https://github.com/humanmade/backupwordpress/">BackUpWordPress on GitHub.</a>
 
-You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> or email support@hmn.md for further help/support.
+You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> or email 7f1l4qyq@incoming.intercom.io for further help/support.
 
 == Screenshots ==
 


### PR DESCRIPTION
Right now, we can get support requests through WordPress.org forums, the support@hmn.md email address, our personal hmn.md email addresses and intercom.io

I'd like to consolidate everything to intercom in the future:
- [ ] Change email address in plugin to the Intercom App email address `xxxx@incoming.intercom.io`
- [ ] Set up the forum alerts to send an email to that address?
- [ ] stop giving our personal email addresses for support?
