### PR TITLE
Add a nonce check to the schedule submit form

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -332,6 +332,8 @@ add_action( 'wp_ajax_hmbkp_add_schedule_load', 'hmbkp_add_schedule_load' );
  */
 function hmbkp_edit_schedule_submit() {
 
+	check_ajax_referer( 'hmbkp_schedule_submit_action', 'hmbkp_schedule_submit_nonce' );
+
 	if ( empty( $_GET['hmbkp_schedule_id'] ) )
 		die;
 

--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -126,7 +126,7 @@
 			$service->field(); ?>
 
 		<p class="submit">
-
+			<?php wp_nonce_field( 'hmbkp_schedule_submit_action', 'hmbkp_schedule_submit_nonce' ); ?>
 			<button type="submit" class="button-primary"><?php _e( 'Update', 'hmbkp' ); ?></button>
 
 		</p>


### PR DESCRIPTION
Ensures schedules can only be started from within the WordPress admin.
