### PR TITLE
Fix double directory separators

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -225,7 +225,7 @@ function hmbkp_ajax_calculate_backup_size() {
 
 	$recalculate_filesize = true;
 
-	include_once( HMBKP_PLUGIN_PATH . '/admin/schedule.php' );
+	include_once( HMBKP_PLUGIN_PATH . 'admin/schedule.php' );
 
 	die;
 
@@ -286,7 +286,7 @@ function hmbkp_edit_schedule_load() {
 
 	$schedule = new HMBKP_Scheduled_Backup( sanitize_text_field( $_GET['hmbkp_schedule_id'] ) );
 
-	require( HMBKP_PLUGIN_PATH . '/admin/schedule-form.php' );
+	require( HMBKP_PLUGIN_PATH . 'admin/schedule-form.php' );
 
 	die;
 
@@ -303,7 +303,7 @@ function hmbkp_edit_schedule_excludes_load() {
 
 	$schedule = new HMBKP_Scheduled_Backup( sanitize_text_field( $_GET['hmbkp_schedule_id'] ) );
 
-	require( HMBKP_PLUGIN_PATH . '/admin/schedule-form-excludes.php' );
+	require( HMBKP_PLUGIN_PATH . 'admin/schedule-form-excludes.php' );
 
 	die;
 
@@ -318,7 +318,7 @@ function hmbkp_add_schedule_load() {
 	$schedule        = new HMBKP_Scheduled_Backup( date( 'U' ) );
 	$is_new_schedule = true;
 
-	require( HMBKP_PLUGIN_PATH . '/admin/schedule-form.php' );
+	require( HMBKP_PLUGIN_PATH . 'admin/schedule-form.php' );
 
 	die;
 
@@ -515,7 +515,7 @@ function hmbkp_add_exclude_rule() {
 
 	$schedule->save();
 
-	require( HMBKP_PLUGIN_PATH . '/admin/schedule-form-excludes.php' );
+	require( HMBKP_PLUGIN_PATH . 'admin/schedule-form-excludes.php' );
 
 	die;
 
@@ -541,7 +541,7 @@ function hmbkp_delete_exclude_rule() {
 
 	$schedule->save();
 
-	require( HMBKP_PLUGIN_PATH . '/admin/schedule-form-excludes.php' );
+	require( HMBKP_PLUGIN_PATH . 'admin/schedule-form-excludes.php' );
 
 	die;
 

--- a/admin/backups.php
+++ b/admin/backups.php
@@ -59,7 +59,7 @@ else {
 
 	<div data-hmbkp-schedule-id="<?php echo esc_attr( $schedule->get_id() ); ?>" class="hmbkp_schedule">
 
-		<?php require( HMBKP_PLUGIN_PATH . '/admin/schedule.php' ); ?>
+		<?php require( HMBKP_PLUGIN_PATH . 'admin/schedule.php' ); ?>
 
 		<table class="widefat">
 

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -23,7 +23,7 @@ add_action( 'admin_menu', 'hmbkp_admin_menu' );
  * @return null
  */
 function hmbkp_manage_backups() {
-	require_once( HMBKP_PLUGIN_PATH . '/admin/page.php' );
+	require_once( HMBKP_PLUGIN_PATH . 'admin/page.php' );
 }
 
 /**

--- a/admin/page.php
+++ b/admin/page.php
@@ -18,7 +18,7 @@
 
 <?php if ( hmbkp_possible() ) : ?>
 
-	<?php include_once( HMBKP_PLUGIN_PATH . '/admin/backups.php' ); ?>
+	<?php include_once( HMBKP_PLUGIN_PATH . 'admin/backups.php' ); ?>
 
 	<p class="howto"><?php printf( __( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory. %2$s', 'hmbkp' ), '<a href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">', '</a>' ); ?></p>
 

--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -72,30 +72,30 @@ if ( ! defined( 'HMBKP_ADMIN_PAGE' ) ) {
 }
 
 // Load the admin menu
-require_once( HMBKP_PLUGIN_PATH . '/admin/menu.php' );
-require_once( HMBKP_PLUGIN_PATH . '/admin/actions.php' );
+require_once( HMBKP_PLUGIN_PATH . 'admin/menu.php' );
+require_once( HMBKP_PLUGIN_PATH . 'admin/actions.php' );
 
 // Load hm-backup
 if ( ! class_exists( 'HM_Backup' ) )
-	require_once( HMBKP_PLUGIN_PATH . '/hm-backup/hm-backup.php' );
+	require_once( HMBKP_PLUGIN_PATH . 'hm-backup/hm-backup.php' );
 
 // Load the schedules
-require_once( HMBKP_PLUGIN_PATH . '/classes/class-schedule.php' );
-require_once( HMBKP_PLUGIN_PATH . '/classes/class-schedules.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-schedule.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-schedules.php' );
 
 // Load the core functions
-require_once( HMBKP_PLUGIN_PATH . '/functions/core.php' );
-require_once( HMBKP_PLUGIN_PATH . '/functions/interface.php' );
+require_once( HMBKP_PLUGIN_PATH . 'functions/core.php' );
+require_once( HMBKP_PLUGIN_PATH . 'functions/interface.php' );
 
 // Load Services
-require_once( HMBKP_PLUGIN_PATH . '/classes/class-services.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-services.php' );
 
 // Load the email service
-require_once( HMBKP_PLUGIN_PATH . '/classes/class-email.php' );
+require_once( HMBKP_PLUGIN_PATH . 'classes/class-email.php' );
 
 // Load the wp cli command
 if ( defined( 'WP_CLI' ) && WP_CLI )
-	include( HMBKP_PLUGIN_PATH . '/classes/wp-cli.php' );
+	include( HMBKP_PLUGIN_PATH . 'classes/wp-cli.php' );
 
 // Hook in the activation and deactivation actions
 register_activation_hook( HMBKP_PLUGIN_SLUG . '/backupwordpress.php', 'hmbkp_activate' );
@@ -265,7 +265,7 @@ add_action( 'init', 'hmbkp_plugin_textdomain', 1 );
  */
 function hmbkp_display_server_info_tab() {
 
-	require_once( HMBKP_PLUGIN_PATH . '/classes/class-requirements.php' );
+	require_once( HMBKP_PLUGIN_PATH . 'classes/class-requirements.php' );
 
 	ob_start();
 	require_once( 'admin/server-info.php' );


### PR DESCRIPTION
This was done in a PR that I had to close. Anyway, better on its own branch.

`include_once( HMBKP_PLUGIN_PATH . '/admin/schedule.php' );`

the constant already has the trailing slash, so this causes a double slash.
![slash_ani](https://cloud.githubusercontent.com/assets/30460/3641900/5b415fee-10ba-11e4-95f2-2b5aadfa6dec.gif)
![slash_ani](https://cloud.githubusercontent.com/assets/30460/3641900/5b415fee-10ba-11e4-95f2-2b5aadfa6dec.gif)
