### PR TITLE
Transients have incorrect expiry

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -63,7 +63,7 @@ function hmbkp_contextual_help() {
 		$plugin = plugins_api( 'plugin_information', array( 'slug' => HMBKP_PLUGIN_SLUG ) );
 
 		// Cache for one day
-		set_transient( 'hmbkp_plugin_data', $plugin, 86400 );
+		set_transient( 'hmbkp_plugin_data', $plugin, 1 * DAY_IN_SECONDS );
 
 	}
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -322,7 +322,7 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 		}
 
 		// If we don't have it in cache then mark it as calculating
-		set_transient( 'hmbkp_schedule_' . $this->get_id() . '_' . $this->get_type() . '_filesize', 'calculating', time() + HOUR_IN_SECONDS );
+		set_transient( 'hmbkp_schedule_' . $this->get_id() . '_' . $this->get_type() . '_filesize', 'calculating', 1 * HOUR_IN_SECONDS );
 
 		// Don't include database if file only
 		if ( $this->get_type() != 'file' ) {
@@ -365,7 +365,7 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 		}
 
 		// Cache for a day
-		set_transient( 'hmbkp_schedule_' . $this->get_id() . '_' . $this->get_type() . '_filesize', $filesize, time() + DAY_IN_SECONDS );
+		set_transient( 'hmbkp_schedule_' . $this->get_id() . '_' . $this->get_type() . '_filesize', $filesize, 1 * DAY_IN_SECONDS );
 
 		return $filesize;
 


### PR DESCRIPTION
Initially reported by aram here: https://github.com/humanmade/WP-Remote-WordPress-Plugin/issues/154 - I realized that the backup code in WP Remote shares a lot with BackUpWordPress - sure enough the same bug is present.

When setting a  transient, the expiry should be the number of seconds before it expires, not the timestame at which it should expire. The consequence of this is that the transients are set to expire such a long time in the future - they never expire.
