### PR TITLE
schedule time displays without timezone diff

### DIFF
--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -75,7 +75,7 @@
 
 			</tr>
 
-			<?php if ( ! $start_time = $schedule->get_schedule_start_time() ) {
+			<?php if ( ! $start_time = $schedule->get_schedule_start_time( false ) ) {
 				$start_time = time();
 			} ?>
 
@@ -101,7 +101,7 @@
 
 						foreach ( $weekdays as $key => $day ) : ?>
 
-							<option value="<?php echo esc_attr( $key ) ?>" <?php selected( strtolower( date( 'l', $start_time ) ), $key ); ?>><?php echo esc_html( $day ); ?></option>
+							<option value="<?php echo esc_attr( $key ) ?>" <?php selected( strtolower( date_i18n( 'l', $start_time ) ), $key ); ?>><?php echo esc_html( $day ); ?></option>
 
 						<?php endforeach; ?>
 
@@ -118,7 +118,7 @@
 				</th>
 
 				<td>
-					<input type="number" min="0" max="31" step="1" id="hmbkp_schedule_start_day_of_month" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_day_of_month]" value="<?php echo esc_attr( date( 'j', $start_time ) ); ?>">
+					<input type="number" min="0" max="31" step="1" id="hmbkp_schedule_start_day_of_month" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_day_of_month]" value="<?php echo esc_attr( date_i18n( 'j', $start_time ) ); ?>">
 				</td>
 
 			</tr>
@@ -132,11 +132,11 @@
 				<td>
 					<span class="field-group">
 
-						<label for="hmbkp_schedule_start_hours"><input type="number" min="0" max="23" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_hours]" id="hmbkp_schedule_start_hours" value="<?php echo esc_attr( date( 'G', $start_time ) ); ?>">
+						<label for="hmbkp_schedule_start_hours"><input type="number" min="0" max="23" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_hours]" id="hmbkp_schedule_start_hours" value="<?php echo esc_attr( date_i18n( 'G', $start_time ) ); ?>">
 
 						<?php _e( 'Hours', 'hmbkp' ); ?></label>
 
-						<label for="hmbkp_schedule_start_minutes"><input type="number" min="0" max="59" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_minutes]" id="hmbkp_schedule_start_minutes" value="<?php echo esc_attr( (float) date( 'i', $start_time ) ); ?>">
+						<label for="hmbkp_schedule_start_minutes"><input type="number" min="0" max="59" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_minutes]" id="hmbkp_schedule_start_minutes" value="<?php echo esc_attr( (float) date_i18n( 'i', $start_time ) ); ?>">
 
 						<?php _e( 'Minutes', 'hmbkp' ); ?></label>
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -390,17 +390,22 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 	 * @access public
 	 * @return int timestamp || 0 for manual only schedules
 	 */
-	public function get_schedule_start_time() {
+	public function get_schedule_start_time( $gmt = true ) {
 
 		if ( $this->get_reoccurrence() === 'manually' )
 			return 0;
 
+		if ( ! $gmt )
+			$offset = get_option( 'gmt_offset' ) * 3600;
+		else
+			$offset = 0;
+
 		if ( ! empty( $this->options['schedule_start_time'] ) )
-			return $this->options['schedule_start_time'];
+			return $this->options['schedule_start_time'] + $offset;
 
 		$this->set_schedule_start_time( time() );
 
-		return time();
+		return time() + $offset;
 
 	}
 


### PR DESCRIPTION
We fixed this before, but it came back: When the timezone is not UTC, and you set the backup start time , it sets it in local time, but displays in UTC
