### PR TITLE
Add an anchor to jump back to on reload

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -472,7 +472,7 @@ function hmbkp_add_exclude_rule() {
 
 	$schedule->save();
 
-	$url = add_query_arg( array( 'action' => 'hmbkp_edit_schedule', 'hmbkp_panel' => 'hmbkp_edit_schedule_excludes' ), hmbkp_get_settings_url() );
+	$url = add_query_arg( array( 'action' => 'hmbkp_edit_schedule', 'hmbkp_panel' => 'hmbkp_edit_schedule_excludes#directory-listing' ), hmbkp_get_settings_url() );
 
 	if ( isset( $_GET['hmbkp_directory_browse'] ) )
 		$url = add_query_arg( 'hmbkp_directory_browse', sanitize_text_field( $_GET['hmbkp_directory_browse'] ), $url );

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -61,7 +61,7 @@
 
 	<?php endif; ?>
 
-	<h3><?php _e( 'Directory Listing', 'hmbkp' ); ?></h3>
+	<h3 id="directory-listing"><?php _e( 'Directory Listing', 'hmbkp' ); ?></h3>
 
 	<p><?php _e( 'Here\'s a directory listing of all files on your site, you can browse through and exclude files or folders that you don\'t want included in your backup.', 'hmbkp' ); ?></p>
 


### PR DESCRIPTION
When adding an exclude rule, on page refresh, jump back to the excludes list, mid-page
