### PR TITLE
remove plugin fails on wp 3.5

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,10 +1,12 @@
 <?php
 
-if ( ! current_user_can( 'activate_plugins' ) )
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	return;
+}
 
-if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) )
-	exit;
+if ( ! current_user_can( 'activate_plugins' ) ) {
+	return;
+}
 
 if ( ! defined( 'HMBKP_REQUIRED_WP_VERSION' ) ) {
 	define( 'HMBKP_REQUIRED_WP_VERSION', '3.8.4' );
@@ -13,11 +15,13 @@ if ( ! defined( 'HMBKP_REQUIRED_WP_VERSION' ) ) {
 // Don't activate on old versions of WordPress
 global $wp_version;
 
-if ( version_compare( $wp_version, HMBKP_REQUIRED_WP_VERSION, '<' ) )
+if ( version_compare( $wp_version, HMBKP_REQUIRED_WP_VERSION, '<' ) ) {
 	return;
+}
 
-if ( ! defined( 'HMBKP_PLUGIN_PATH' ) )
+if ( ! defined( 'HMBKP_PLUGIN_PATH' ) ) {
 	define( 'HMBKP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+}
 
 // Load the schedules
 require_once( HMBKP_PLUGIN_PATH . 'hm-backup/hm-backup.php' );
@@ -42,6 +46,6 @@ foreach ( array( 'hmbkp_enable_support', 'hmbkp_plugin_version', 'hmbkp_path', '
 }
 
 // Delete all transients
-foreach( array( 'hmbkp_plugin_data', 'hmbkp_directory_filesizes', 'hmbkp_directory_filesize_running' ) as $transient ) {
+foreach ( array( 'hmbkp_plugin_data', 'hmbkp_directory_filesizes', 'hmbkp_directory_filesize_running' ) as $transient ) {
 	delete_transient( $transient );
 }


### PR DESCRIPTION
Removing plugin from older WP (where it can't be activated) fails with message:

```
Fatal error: Call to undefined function wp_is_writable() in .../wp-content/plugins/backupwordpress/functions/core.php on line 380
```

Easy solution would be to add:

``` PHP
if ( !function_exists('wp_is_writable') ) {
// copy wp_is_writable function from /wp-includes/functions.php
}
```
