### PR TITLE
Feedback from Steven re excludes

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -475,12 +475,6 @@ function hmbkp_add_exclude_rule() {
 
 	$schedule->save();
 
-	$url = add_query_arg( array( 'action' => 'hmbkp_edit_schedule', 'hmbkp_panel' => 'hmbkp_edit_schedule_excludes#directory-listing' ), hmbkp_get_settings_url() );
-
-	if ( isset( $_GET['hmbkp_directory_browse'] ) ) {
-		$url = add_query_arg( 'hmbkp_directory_browse', sanitize_text_field( $_GET['hmbkp_directory_browse'] ), $url );
-	}
-
 	wp_safe_redirect( wp_get_referer(), '303' );
 
 	die;
@@ -509,12 +503,6 @@ function hmbkp_remove_exclude_rule() {
 	$schedule->set_excludes( array_diff( $excludes, (array) stripslashes( sanitize_text_field( $_GET['hmbkp_remove_exclude'] ) ) ) );
 
 	$schedule->save();
-
-	$url = add_query_arg( array( 'action' => 'hmbkp_edit_schedule', 'hmbkp_panel' => 'hmbkp_edit_schedule_excludes' ), hmbkp_get_settings_url() );
-
-	if ( isset( $_GET['hmbkp_directory_browse'] ) ) {
-		$url = add_query_arg( 'hmbkp_directory_browse', sanitize_text_field( $_GET['hmbkp_directory_browse'] ), $url );
-	}
 
 	wp_safe_redirect( wp_get_referer(), '303' );
 


### PR DESCRIPTION
> So when you exclude a file there's no confirmation (except the fact it's now in your list of excluded files). Also if you're browsing in wp-content and exclude a file you're then brought back to the root. One big thing missing too, not sure if it's on your roadmap - excluding multiple files. (checkboxes eg)

I was going to split these into different tickets but thought I'd dump them here first.

Great feedback, couple of things we should do now.
- [ ] Add an AYS confirmation when excluding a file.
- [x] Make sure we reload the excludes filelist in the correct place when someone excludes a file.

I think we can leave checkboxes for future.
