### PR TITLE
Tests for setting schedules are failing

### DIFF
--- a/tests/testScheduleTest.php
+++ b/tests/testScheduleTest.php
@@ -78,7 +78,7 @@ class testScheduleTestCase extends HM_Backup_UnitTestCase {
 	public function set_past_start_time() {
 
 		$this->assertTrue( is_wp_error( $this->schedule->set_schedule_start_time( $this->time() - 7200 ) ) );
-		$this->assertEquals( $this->schedule->get_schedule_start_time(), $this->time() );
+		$this->assertEquals( $this->schedule->get_schedule_start_time(), $this->time(), '', 30 );
 
 	}
 
@@ -95,10 +95,10 @@ class testScheduleTestCase extends HM_Backup_UnitTestCase {
 			$this->assertEquals( $reoccurrence, $this->schedule->get_reoccurrence() );
 
 			// The default start time should be now
-			$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time() );
+			$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time(), '', 30 );
 
 			// Check that the start time is the same as the next occurance
-			$this->assertEquals( $this->time(), $this->schedule->get_next_occurrence() );
+			$this->assertEquals( $this->time(), $this->schedule->get_next_occurrence(), '', 30 );
 
 		}
 
@@ -115,10 +115,10 @@ class testScheduleTestCase extends HM_Backup_UnitTestCase {
 		$this->assertEquals( 'hmbkp_hourly', $this->schedule->get_reoccurrence() );
 
 		// The default start time should be now
-		$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time() );
+		$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time(), '', 30 );
 
 		// Check that the start time is the same as the next occurance
-		$this->assertEquals( $this->time(), $this->schedule->get_next_occurrence() );
+		$this->assertEquals( $this->time(), $this->schedule->get_next_occurrence(), '', 30 );
 
 		$this->schedule->save();
 
@@ -128,10 +128,10 @@ class testScheduleTestCase extends HM_Backup_UnitTestCase {
 		$this->schedule->__construct( 'unit-test' );
 
 		// The default start time should be now
-		$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time() );
+		$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time(), '', 30 );
 
 		// Check that the start time is the same as the next occurance
-		$this->assertEquals( $this->schedule->get_next_occurrence(), $this->time() );
+		$this->assertEquals( $this->schedule->get_next_occurrence(), $this->time(), '', 30 );
 
 	}
 
@@ -148,9 +148,9 @@ class testScheduleTestCase extends HM_Backup_UnitTestCase {
 			$this->assertEquals( 'hmbkp_hourly', $this->schedule->get_reoccurrence() );
 
 			$this->assertFalse( is_wp_error( $this->schedule->set_schedule_start_time( $this->time() + 7200 ) ) );
-			$this->assertEquals( $this->schedule->get_schedule_start_time(), $this->time() + 7200 );
+			$this->assertEquals( $this->schedule->get_schedule_start_time(), $this->time() + 7200, '', 30 );
 
-			$this->assertEquals( $this->schedule->get_next_occurrence(), $this->time() + 7200 );
+			$this->assertEquals( $this->schedule->get_next_occurrence(), $this->time() + 7200, '', 30 );
 
 		}
 
@@ -167,10 +167,10 @@ class testScheduleTestCase extends HM_Backup_UnitTestCase {
 		$this->assertEquals( 'hmbkp_hourly', $this->schedule->get_reoccurrence() );
 
 		// The default start time should be now
-		$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time() );
+		$this->assertEquals( $this->time(), $this->schedule->get_schedule_start_time(), '', 30 );
 
 		// Check that the start time is the same as the next occurance
-		$this->assertEquals( $this->time(), $this->schedule->get_next_occurrence() );
+		$this->assertEquals( $this->time(), $this->schedule->get_next_occurrence(), '', 30 );
 
 		$this->schedule->unschedule();
 


### PR DESCRIPTION
![screenshot 2014-09-22 19 42 05](https://cloud.githubusercontent.com/assets/30460/4365196/d5eee556-42a9-11e4-9065-f4f24e0da5a8.png)
![screenshot 2014-09-22 19 41 56](https://cloud.githubusercontent.com/assets/30460/4365199/d8d8e26c-42a9-11e4-8940-d8c5a712469d.png)
![screenshot 2014-09-22 19 41 40](https://cloud.githubusercontent.com/assets/30460/4365200/d90d9cc8-42a9-11e4-997a-240707c22716.png)

So there's sometimes a second difference which causes the test to fail

I think this is because we get `time()` in the test class, and we set the schedule to `time()` in the schedule class? So there can be a delay between the two
