### PR TITLE
waffle.io Badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/humanmade/backupwordpress.png?label=ready&title=Ready)](https://waffle.io/humanmade/backupwordpress)
 [![Coverage Status](https://img.shields.io/coveralls/humanmade/backupwordpress.svg)](https://coveralls.io/r/humanmade/backupwordpress?branch=master)
 
 [![Build Status](https://travis-ci.org/humanmade/backupwordpress.svg?branch=master)](https://travis-ci.org/humanmade/backupwordpress)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/humanmade/backupwordpress

This was requested by a real person (user pdewouters) on waffle.io, we're not trying to spam you.
