### PR TITLE
Reports of Warning: Invalid argument supplied for foreach() /backupwordpress/classes/class-schedule.php on line 531

### DIFF
--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -508,7 +508,9 @@ class HMBKP_Scheduled_Backup extends HM_Backup {
 		if ( $file->isDir() ) {
 
 			// If we haven't calculated the site size yet then kick it off in a thread
-			if ( ! $directory_sizes = get_transient( 'hmbkp_directory_filesizes' ) ) {
+			$directory_sizes = get_transient( 'hmbkp_directory_filesizes' );
+
+			if ( ! is_array( $directory_sizes ) ) {
 
 				if ( ! $this->is_site_size_being_calculated() ) {
 


### PR DESCRIPTION
@pdewouters there's a few reports of this error coming in. Can you look into this?

https://app.intercom.io/a/apps/7f1l4qyq/inbox/all/conversations/631507515 

There's another ticket up with FTP access if you want to debug on someones site.
