### PR TITLE
Make upsell sentence translatable

### DIFF
--- a/admin/upsell.php
+++ b/admin/upsell.php
@@ -10,7 +10,7 @@
 		<a target="_blank" href="http://bwp.hmn.md/downloads/backupwordpress-to-rackspace-cloud/" alt="Rackspace Cloud">Rackspace Cloud</a> | 
 		<a target="_blank" href="http://bwp.hmn.md/downloads/backupwordpress-to-windows-azure/">Windows Azure</a> | 
 		<a target="_blank" href="http://bwp.hmn.md/downloads/backupwordpress-to-dreamobjects/">DreamObjects</a>
-	</span>
+	</span>&nbsp;
 
-<?php printf( __( '&nbsp;%1$sor buy the %2$sDeveloper Bundle</a> now for only &dollar;99 (all Destinations &amp; Unlimited Sites)%3$s', 'backupwordpress' ), '<span>', '<a target="_blank" href="https://bwp.hmn.md/checkout?edd_action=add_to_cart&download_id=36">', '</span>'  ); ?>
+<?php printf( __( '%1$sor buy the %2$sDeveloper Bundle%3$s now for only &dollar;99 (all Destinations &amp; Unlimited Sites)%4$s', 'backupwordpress' ), '<span>', '<a target="_blank" href="https://bwp.hmn.md/checkout?edd_action=add_to_cart&download_id=36">', '</a>', '</span>'  ); ?>
 </div>


### PR DESCRIPTION
We missed a few strings for i18n. This fixes the issue.
