### PR TITLE
Backup errors should show in network admin

### DIFF
--- a/functions/interface.php
+++ b/functions/interface.php
@@ -47,6 +47,12 @@ function hmbkp_get_backup_row( $file, HMBKP_Scheduled_Backup $schedule ) {
  */
 function hmbkp_admin_notices() {
 
+	$current_screen = get_current_screen();
+
+	if ( ! isset( $current_screen ) || HMBKP_ADMIN_PAGE !== $current_screen->id ) {
+		return;
+	}
+
 	$notices = HMBKP_Notices::get_instance()->get_notices();
 	
 	if ( empty( $notices ) ) {


### PR DESCRIPTION
Currently when the plugin is network activated all errors still show in the individual site admins, they should instead show in network admin.

Case in-point, our hmn.md network currently shows the following error on all sub-sites and on the main site just shows a blank page for the backups page.

![screen shot 2014-12-12 at 10 42 15](https://cloud.githubusercontent.com/assets/308507/5410407/0041d364-81ec-11e4-9033-f35824025295.png)
