### PR TITLE
Fixes issue preventing backups from running without JS

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -69,7 +69,7 @@ function hmbkp_request_do_backup() {
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 		check_ajax_referer( 'hmbkp_run_schedule', 'hmbkp_run_schedule_nonce' );
 	} else {
-		check_admin_referer( 'hmbkp-run-schedule', 'hmbkp-run-schedule' );
+		check_admin_referer( 'hmbkp_run_schedule', 'hmbkp_run_schedule_nonce' );
 	}
 
 	// Fixes an issue on servers which only allow a single session per client
@@ -123,7 +123,7 @@ function hmbkp_request_do_backup() {
 
 }
 add_action( 'wp_ajax_hmbkp_run_schedule', 'hmbkp_request_do_backup' );
-add_action( 'admin_post_hmbkp_request_do_backup', 'hmbkp_request_do_backup' );
+add_action( 'admin_post_hmbkp_run_schedule', 'hmbkp_request_do_backup' );
 
 /**
  * Send the download file to the browser and then redirect back to the backups page

--- a/admin/schedule-settings.php
+++ b/admin/schedule-settings.php
@@ -2,7 +2,7 @@
 
 	<div class="hmbkp-schedule-actions row-actions">
 
-		<a class="hmbkp-run" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'hmbkp_run_schedule', 'hmbkp_schedule_id' => $schedule->get_id() ), hmbkp_get_settings_url() ) ), 'hmbkp-run-schedule' ); ?>"><?php _e( 'Run now', 'backupwordpress' ); ?></a>  |
+		<a class="hmbkp-run" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'hmbkp_run_schedule', 'hmbkp_schedule_id' => $schedule->get_id() ), admin_url( 'admin-post.php' ) ), 'hmbkp_run_schedule', 'hmbkp_run_schedule_nonce' ) ); ?>"><?php _e( 'Run now', 'backupwordpress' ); ?></a>  |
 
 		<a href="<?php echo esc_url( add_query_arg( array( 'action' => 'hmbkp_edit_schedule', 'hmbkp_panel' => 'hmbkp_edit_schedule_settings', 'hmbkp_schedule_id' => $schedule->get_id() ), hmbkp_get_settings_url() ), 'hmbkp-edit-schedule' ); ?>"><?php _e( 'Settings', 'backupwordpress' ); ?></a> |
 


### PR DESCRIPTION
Not currently possible to run a backup if JS is broken / disabled, this PR fixes up the bugs that were breaking that.

Correct action, url and nonce for nojs backups
