### PR TITLE
Scheduled backups shouldn't run if backups are not possible

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -359,6 +359,10 @@ class BackUpWordPress_Plugin {
 	 */
 	public function schedule_hook_run( $schedule_id ) {
 
+		if ( ! hmbkp_possible() ) {
+			return;
+		}
+
 		$schedules = HMBKP_Schedules::get_instance();
 		$schedule  = $schedules->get_schedule( $schedule_id );
 


### PR DESCRIPTION
"Noticed the following error on the hmn.md network:

```
E_WARNING: fopen(s3:/***/*****-production/uploads/sites/5/backupwordpress-*******-backups/.schedule-default-1-running): failed to open stream: No such file or directory
```

The error is caused because a scheduled backup is trying to run even though the backups directory doesn't exist / isn't writable.

However the backup scheduled shouldn't be running in this situation, we have a function `hmbkp_possible()` which checks for such a thing and if those checks fail we disable the backups page completely and show a warning message. It looks like we missed also disabling scheduled backups