### PR TITLE
Backups list incorrect time

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -329,7 +329,7 @@ namespace HM\BackUpWordPress {
 		public function get_archive_filename() {
 
 			if ( empty( $this->archive_filename ) ) {
-				$this->set_archive_filename( implode( '-', array( sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), 'backup', date( 'Y-m-d-H-i-s', current_time( 'timestamp' ) ) ) ) . '.zip' );
+				$this->set_archive_filename( implode( '-', array( sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), 'backup', date( 'Y-m-d-H-i-s', time() ) ) ) . '.zip' );
 			}
 
 			return $this->archive_filename;

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -69,7 +69,7 @@ class Scheduled_Backup {
 		$this->backup = new Backup();
 
 		// Set the archive filename to site name + schedule slug + date
-		$this->backup->set_archive_filename( implode( '-', array( sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), $this->get_id(), $this->get_type(), date( 'Y-m-d-H-i-s', current_time( 'timestamp' ) ) ) ) . '.zip' );
+		$this->backup->set_archive_filename( implode( '-', array( sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), $this->get_id(), $this->get_type(), date( 'Y-m-d-H-i-s', time() ) ) ) . '.zip' );
 
 		$this->backup->set_database_dump_filename( implode( '-', array( 'database', sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), $this->get_id() ) ) . '.sql' );
 

--- a/functions/core.php
+++ b/functions/core.php
@@ -115,7 +115,7 @@ function hmbkp_update() {
 		}
 
 		// Set the archive filename to what it used to be
-		$legacy_schedule->backup->set_archive_filename( implode( '-', array( get_bloginfo( 'name' ), 'backup', date( 'Y-m-d-H-i-s', current_time( 'timestamp' ) ) ) ) . '.zip' );
+		$legacy_schedule->backup->set_archive_filename( implode( '-', array( get_bloginfo( 'name' ), 'backup', date( 'Y-m-d-H-i-s', time() ) ) ) . '.zip' );
 
 		$legacy_schedule->save();
 


### PR DESCRIPTION
A user did some debugging on BWP and this was his result.

>I have now looked at your code and determined the problem is caused by using 'date' in conjunction with current_time. The timezone offset is getting applied twice, once in each function.
>
>When given a timestamp, 'date' expects it to be the seconds from when the unix clock began, GMT. It then provides local offset time. 
http://php.net/manual/en/function.date.php
>
>Current_time does the same thing. It expects seconds from epoch, GMT and it applies the offset. 
http://codex.wordpress.org/Function_Reference/current_time
>
>In PHP 5.1+ date_default_timezone started having an impact. It is settable on the system (mine is default) and it is settable in code, which wordpress does on the settings page. When I call date_default_timezone_get() from within wordpress it correctly reports Denver / MST / -7. 
http://php.net/manual/en/function.date-default-timezone-set.php 
http://vip.wordpress.com/documentation/vip-development-tips-tricks/use-current_time-not-date_default_timezone_set/
>
>In several classes you use: 
>date('Y-m-d H-i-s',current_time('timestamp')) 
>This results in a 2x Offset.
>
>Instead you should use one of the following options:
>
>date('Y-m-d H-i-s', current_time('timestamp', 1))
>
>current_time('Y-m-d H-i-s', 1)
>
>gmdate('Y-m-d H-i-s', current_time('timestamp'))