### PR TITLE
Email settings field may not be saving

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -217,8 +217,6 @@ function hmbkp_edit_schedule_services_submit() {
 
 	$schedule = new HM\BackUpWordPress\Scheduled_Backup( sanitize_text_field( $_POST['hmbkp_schedule_id'] ) );
 
-	hmbkp_clear_settings_errors();
-
 	$errors = array();
 
 	// Save the service options
@@ -254,8 +252,6 @@ function hmbkp_edit_schedule_submit() {
 	}
 
 	$schedule = new HM\BackUpWordPress\Scheduled_Backup( sanitize_text_field( $_POST['hmbkp_schedule_id'] ) );
-
-	hmbkp_clear_settings_errors();
 
 	$errors = array();
 

--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -12,7 +12,12 @@
 
 	</div>
 
-<?php } ?>
+<?php }
+
+// We can clear them now we've displayed them
+hmbkp_clear_settings_errors();
+
+?>
 
 <form method="post" action="<?php echo admin_url( 'admin-post.php' ); ?>">
 

--- a/admin/schedule-settings.php
+++ b/admin/schedule-settings.php
@@ -67,7 +67,14 @@ if ( HM\BackUpWordPress\Schedules::get_instance()->get_schedule( $schedule->get_
 
 				</div>
 
-			<?php endif; ?>
+			<?php
+
+			endif;
+
+			// We can clear them now we've displayed them
+			hmbkp_clear_settings_errors();
+
+			?>
 
 			<form method="post" action="<?php echo admin_url( 'admin-post.php' ); ?>">
 


### PR DESCRIPTION
Had a few reports of the email notification settings field not saving the email address entered.

https://app.intercom.io/a/apps/7f1l4qyq/inbox/all/conversations/721264065
https://app.intercom.io/a/apps/7f1l4qyq/inbox/all/conversations/720633313

***How to test***

Activate BWP and an addon.
Try entering an invalid email address in the email notification field. Should reload and display an error notice.
Entering a valid email should clear notice.
Enter the settings for an addon - but omit one of the fields. Should reload and display a notice that the field is required
Fill in correct info and notice should be cleared.
