### PR TITLE
Use the Service name as the setting name

### DIFF
--- a/classes/class-service.php
+++ b/classes/class-service.php
@@ -94,7 +94,7 @@ abstract class Service {
 	 * @return string       The formated name
 	 */
 	protected function get_field_name( $name ) {
-		return esc_attr( get_class( $this ) . '[' . $name . ']' );
+		return esc_attr( $this->get_slug() . '[' . $name . ']' );
 	}
 
 	/**
@@ -106,8 +106,8 @@ abstract class Service {
 	 */
 	protected function get_field_value( $name, $esc = 'esc_attr' ) {
 
-		if ( $name && $this->schedule->get_service_options( get_class( $this ), $name ) ) {
-			return $esc( $this->schedule->get_service_options( get_class( $this ), $name ) );
+		if ( $name && $this->schedule->get_service_options( $this->get_slug(), $name ) ) {
+			return $esc( $this->schedule->get_service_options( $this->get_slug(), $name ) );
 		}
 
 		return '';
@@ -121,7 +121,7 @@ abstract class Service {
 	 */
 	public function save() {
 
-		$classname = get_class( $this );
+		$classname = $this->get_slug();
 
 		$old_data = $this->schedule->get_service_options( $classname );
 
@@ -132,7 +132,7 @@ abstract class Service {
 		if ( $errors && $errors = array_flip( $errors ) ) {
 
 			foreach ( $errors as $error => &$field ) {
-				$field = get_class( $this ) . '[' . $field . ']';
+				$field = $this->get_slug() . '[' . $field . ']';
 			}
 
 			return array_flip( $errors );
@@ -165,7 +165,7 @@ abstract class Service {
 	 */
 	protected function fetch_destination_settings() {
 
-		$service = get_class( $this );
+		$service = $this->get_slug();
 
 		$schedules_obj = Schedules::get_instance();
 


### PR DESCRIPTION
This pull request changes the service settings name to use the slugified service name `google-drive` or `ftp` instead of `HM\BackUpWordPressGoogleDrive\`
It's just a theory that backslashes in setting names could potentially not work well in some server configs. Also it's easier to work with. For example in jQuery you have to escape the backslashes like `\\\\` 
This change requires migrating the old settings to the new settings. Also, this revealed the fact that when we added namespaces it broke the existing settings because `get_class` adds the namespace so the settings were persisted under a different option name.

