### PR TITLE
Fixes settings not saving

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -3,7 +3,7 @@
 Plugin Name: BackUpWordPress
 Plugin URI: http://bwp.hmn.md/
 Description: Simple automated backups of your WordPress powered website. Once activated you'll find me under <strong>Tools &rarr; Backups</strong>. On multisite, you'll find me under the Network Settings menu.
-Version: 3.1.3
+Version: 3.1.4
 Author: Human Made Limited
 Author URI: http://hmn.md/
 License: GPL-2.0+
@@ -43,7 +43,7 @@ register_deactivation_hook( __FILE__, array( 'HM\BackUpWordPress\Setup', 'deacti
  */
 final class Plugin {
 
-	const PLUGIN_VERSION = '3.1.3';
+	const PLUGIN_VERSION = '3.1.4';
 
 	/**
 	 * @var Plugin The singleton instance.

--- a/classes/class-service.php
+++ b/classes/class-service.php
@@ -94,7 +94,7 @@ abstract class Service {
 	 * @return string       The formated name
 	 */
 	protected function get_field_name( $name ) {
-		return esc_attr( get_class( $this ) . '[' . $name . ']' );
+		return esc_attr( $this->get_slug() . '[' . $name . ']' );
 	}
 
 	/**
@@ -106,8 +106,8 @@ abstract class Service {
 	 */
 	protected function get_field_value( $name, $esc = 'esc_attr' ) {
 
-		if ( $name && $this->schedule->get_service_options( get_class( $this ), $name ) ) {
-			return $esc( $this->schedule->get_service_options( get_class( $this ), $name ) );
+		if ( $name && $this->schedule->get_service_options( $this->get_slug(), $name ) ) {
+			return $esc( $this->schedule->get_service_options( $this->get_slug(), $name ) );
 		}
 
 		return '';
@@ -121,7 +121,7 @@ abstract class Service {
 	 */
 	public function save() {
 
-		$classname = get_class( $this );
+		$classname = $this->get_slug();
 
 		$old_data = $this->schedule->get_service_options( $classname );
 
@@ -132,7 +132,7 @@ abstract class Service {
 		if ( $errors && $errors = array_flip( $errors ) ) {
 
 			foreach ( $errors as $error => &$field ) {
-				$field = get_class( $this ) . '[' . $field . ']';
+				$field = $this->get_slug() . '[' . $field . ']';
 			}
 
 			return array_flip( $errors );
@@ -165,7 +165,7 @@ abstract class Service {
 	 */
 	protected function fetch_destination_settings() {
 
-		$service = get_class( $this );
+		$service = $this->get_slug();
 
 		$schedules_obj = Schedules::get_instance();
 

--- a/classes/class-service.php
+++ b/classes/class-service.php
@@ -84,7 +84,7 @@ abstract class Service {
 	abstract public function action( $action, Backup $backup );
 
 	public function get_slug() {
-		return strtolower( sanitize_title_with_dashes( $this->name ) );
+		return sanitize_title_with_dashes( $this->name );
 	}
 
 	/**

--- a/functions/core.php
+++ b/functions/core.php
@@ -163,6 +163,60 @@ function hmbkp_update() {
 
 	}
 
+	// update to 3.1.4
+	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( '3.1.4', get_option( 'hmbkp_plugin_version' ), '>' ) ) {
+
+		$old_option_names = array(
+			'HM\BackUpWordPressDropbox\Dropbox_Service'    => 'dropbox',
+			'HMBKP_DX_Backup_Service'                      => 'dropbox',
+			'HM\BackUpWordPressFTP\FTP_Backup_Service'     => 'ftp',
+			'HMBKP_FTP_Backup_Service'                     => 'ftp',
+			'HM\BackUpWordPressGDrive\Google_Drive_BackUp' => 'google-drive',
+			'HMBKP_GDV_Backup_Service'                     => 'google-drive',
+			'HM\BackUpWordPressRackspace\RackSpace_BackUp' => 'rackspace-cloud',
+			'HMBKP_RSC_Backup_Service'                     => 'rackspace-cloud',
+			'HM\BackUpWordPressS3\S3_Backup'               => 's3',
+			'HMBKP_S3_Backup_Service'                      => 's3',
+			'HM\BackUpWordPressWinAzure\WinAzure_Backup'   => 'azure',
+			'HMBKP_WAZ_Backup_Service'                     => 'azure',
+			'HM\BackUpWordPress\Email_Service'             => 'email',
+		);
+
+		global $wpdb;
+
+		// Get all schedule options with a SELECT query and delete them.
+		$schedules = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s", 'hmbkp_schedule_%' ) );
+
+		if ( 0 < count( $schedules ) ) {
+
+			// Access each schedules settings to see if the addon settings names need to be be updated to the new naming convention which uses the service slug generated from the $name property.
+			foreach ( $schedules as $schedule_id ) {
+
+				// Load the settings for this schedule into an array
+				// so we can loop through the different service settings
+				$schedule_settings = get_option( $schedule_id );
+
+				// Iterate over each schedule setting for this schedule and check its name against our array.
+				foreach ( $schedule_settings as $key => $val ) {
+					// Find the current element key in our control array and get its value. Set a new element in the settings array with the found value as its key. Aka rename the element key
+					if ( array_key_exists( $key, $old_option_names ) ) {
+
+						// move the value to our new key
+						$schedule_settings[ $old_option_names[ $key ] ] = $schedule_settings[ $key ];
+
+						unset( $schedule_settings[ $key ] );
+
+					}
+				}
+
+				// Save back to the DB
+				update_option( $schedule_id, $schedule_settings );
+			}
+		}
+
+
+	}
+
 	// Every update
 	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( HM\BackUpWordPress\Plugin::PLUGIN_VERSION, get_option( 'hmbkp_plugin_version' ), '>' ) ) {
 


### PR DESCRIPTION
Fixes a bug with the Service settings that were not being saved because of the backslashes in the settings key names.
Also migrates any existing settings to the new naming convention. If multiple version of settings names are present in the DB, then only one will be kept.

For example, an existing site with the Google Drive addon could have 2 different serialized schedule settings for services:
`HMBKP_GDV_Backup_Service`
`HM\BackUpWordPressGDrive\Google_Drive_BackUp`

The new setting name will be `google-drive`
The upgrade routine will loop over these two and whichever one is the last to be iterated over will carry its values over to the new setting.