### PR TITLE
Exclude Envato-backups folders by default

### DIFF
--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -35,7 +35,7 @@
 
 						<td>
 
-							<?php if ( ( hmbkp_path() === untrailingslashit( $exclude ) ) || ( in_array( $exclude, $schedule->default_excludes() ) ) ) : ?>
+							<?php if ( ( hmbkp_path() === untrailingslashit( $exclude ) ) ) : ?>
 
 								<?php _e( 'Default rule', 'backupwordpress' ); ?>
 

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -146,7 +146,7 @@
 
 						$root = new SplFileInfo( $schedule->backup->get_root() );
 
-						$size = $schedule->filesize( $root );
+						$size = $schedule->filesize( $root, true );
 
 						if ( false !== $size ) {
 

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -35,11 +35,11 @@
 
 					<td>
 
-						<?php if ( ( hmbkp_path() === untrailingslashit( $exclude ) ) ) : ?>
+						<?php if ( ( in_array( $exclude, $schedule->backup->default_excludes() ) ) || ( hmbkp_path() === untrailingslashit( $exclude ) ) ) : ?>
 
 							<?php _e( 'Default rule', 'backupwordpress' ); ?>
 
-						<?php elseif ( defined( 'HMBKP_EXCLUDE' ) && strpos( HMBKP_EXCLUDE, $exclude ) !== false ) : ?>
+						<?php elseif ( defined( 'HMBKP_EXCLUDE' ) && false !== strpos( HMBKP_EXCLUDE, $exclude ) ) : ?>
 
 							<?php _e( 'Defined in wp-config.php', 'backupwordpress' ); ?>
 
@@ -78,7 +78,7 @@
 		$untrusted_directory = urldecode( $_GET['hmbkp_directory_browse'] );
 
 		// Only allow real sub directories of the site root to be browsed
-		if ( strpos( $untrusted_directory, $schedule->backup->get_root() ) !== false && is_dir( $untrusted_directory ) ) {
+		if ( false !== strpos( $untrusted_directory, $schedule->backup->get_root() ) && is_dir( $untrusted_directory ) ) {
 			$directory = $untrusted_directory;
 		}
 
@@ -114,14 +114,14 @@
 
 					<?php if ( $schedule->backup->get_root() !== $directory ) { ?>
 
-						<a href="<?php echo remove_query_arg( 'hmbkp_directory_browse' ); ?>"><?php echo esc_html( $schedule->backup->get_root() ); ?></a>
+						<a href="<?php echo esc_url( remove_query_arg( 'hmbkp_directory_browse' ) ); ?>"><?php echo esc_html( $schedule->backup->get_root() ); ?></a>
 						<code>/</code>
 
 						<?php $parents = array_filter( explode( '/', str_replace( trailingslashit( $schedule->backup->get_root() ), '', trailingslashit( dirname( $directory ) ) ) ) );
 
 						foreach ( $parents as $directory_basename ) { ?>
 
-							<a href="<?php echo add_query_arg( 'hmbkp_directory_browse', urlencode( substr( $directory, 0, strpos( $directory, $directory_basename ) ) . $directory_basename ) ); ?>"><?php echo esc_html( $directory_basename ); ?></a>
+							<a href="<?php echo esc_url( add_query_arg( 'hmbkp_directory_browse', urlencode( substr( $directory, 0, strpos( $directory, $directory_basename ) ) . $directory_basename ) ) ); ?>"><?php echo esc_html( $directory_basename ); ?></a>
 							<code>/</code>
 
 						<?php } ?>
@@ -148,7 +148,7 @@
 
 						$size = $schedule->filesize( $root );
 
-						if ( $size !== false ) {
+						if ( false !== $size ) {
 
 							$size = size_format( $size );
 

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -357,9 +357,9 @@
 
 	<?php } ?>
 
-</div>
+	<p class="submit">
+		<a href="<?php echo esc_url( hmbkp_get_settings_url() ) ?>"
+		   class="button-primary"><?php _e( 'Done', 'backupwordpress' ); ?></a>
+	</p>
 
-<p class="submit">
-	<a href="<?php echo esc_url( hmbkp_get_settings_url() ) ?>"
-	   class="button-primary"><?php _e( 'Done', 'backupwordpress' ); ?></a>
-</p>
+</div>

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -8,52 +8,55 @@
 
 			<tbody>
 
-				<?php foreach ( $schedule->get_excludes() as $key => $exclude ) :
+			<?php foreach ( $schedule->get_excludes() as $key => $exclude ) :
 
-					$exclude_path = new SplFileInfo( trailingslashit( $schedule->backup->get_root() ) . ltrim( str_ireplace( $schedule->backup->get_root(), '', $exclude ), '/' ) ); ?>
+				$exclude_path = new SplFileInfo( trailingslashit( $schedule->backup->get_root() ) . ltrim( str_ireplace( $schedule->backup->get_root(), '', $exclude ), '/' ) ); ?>
 
-					<tr>
+				<tr>
 
-						<th scope="row">
+					<th scope="row">
 
-							<?php if ( $exclude_path->isFile() ) { ?>
+						<?php if ( $exclude_path->isFile() ) { ?>
 
-								<div class="dashicons dashicons-media-default"></div>
+							<div class="dashicons dashicons-media-default"></div>
 
-							<?php } elseif ( $exclude_path->isDir() ) { ?>
+						<?php } elseif ( $exclude_path->isDir() ) { ?>
 
-								<div class="dashicons dashicons-portfolio"></div>
+							<div class="dashicons dashicons-portfolio"></div>
 
-							<?php } ?>
+						<?php } ?>
 
-						</th>
+					</th>
 
-						<td>
-							<code><?php echo esc_html( str_ireplace( $schedule->backup->get_root(), '', $exclude ) ); ?></code>
+					<td>
+						<code><?php echo esc_html( str_ireplace( $schedule->backup->get_root(), '', $exclude ) ); ?></code>
 
-						</td>
+					</td>
 
-						<td>
+					<td>
 
-							<?php if ( ( hmbkp_path() === untrailingslashit( $exclude ) ) ) : ?>
+						<?php if ( ( hmbkp_path() === untrailingslashit( $exclude ) ) ) : ?>
 
-								<?php _e( 'Default rule', 'backupwordpress' ); ?>
+							<?php _e( 'Default rule', 'backupwordpress' ); ?>
 
-							<?php elseif ( defined( 'HMBKP_EXCLUDE' ) && strpos( HMBKP_EXCLUDE, $exclude ) !== false ) : ?>
+						<?php elseif ( defined( 'HMBKP_EXCLUDE' ) && strpos( HMBKP_EXCLUDE, $exclude ) !== false ) : ?>
 
-								<?php _e( 'Defined in wp-config.php', 'backupwordpress' ); ?>
+							<?php _e( 'Defined in wp-config.php', 'backupwordpress' ); ?>
 
-							<?php else : ?>
+						<?php else : ?>
 
-								<a href="<?php echo hmbkp_admin_action_url( 'remove_exclude_rule', array( 'hmbkp_remove_exclude' => $exclude, 'hmbkp_schedule_id' => $schedule->get_id() ) ); ?>" class="delete-action"><?php _e( 'Stop excluding', 'backupwordpress' ); ?></a>
+							<a href="<?php echo hmbkp_admin_action_url( 'remove_exclude_rule', array(
+								'hmbkp_remove_exclude' => $exclude,
+								'hmbkp_schedule_id'    => $schedule->get_id()
+							) ); ?>" class="delete-action"><?php _e( 'Stop excluding', 'backupwordpress' ); ?></a>
 
-							<?php endif; ?>
+						<?php endif; ?>
 
-						</td>
+					</td>
 
-					</tr>
+				</tr>
 
-				<?php endforeach; ?>
+			<?php endforeach; ?>
 
 			</tbody>
 
@@ -70,7 +73,7 @@
 	// The directory to display
 	$directory = $schedule->backup->get_root();
 
-	if ( isset( $_GET['hmbkp_directory_browse'] )  ) {
+	if ( isset( $_GET['hmbkp_directory_browse'] ) ) {
 
 		$untrusted_directory = urldecode( $_GET['hmbkp_directory_browse'] );
 
@@ -92,58 +95,173 @@
 
 			<thead>
 
-				<tr>
-					<th></th>
-					<th scope="col"><?php _e( 'Name', 'backupwordpress' ); ?></th>
-					<th scope="col" class="column-format"><?php _e( 'Size', 'backupwordpress' ); ?></th>
-					<th scope="col" class="column-format"><?php _e( 'Permissions', 'backupwordpress' ); ?></th>
-					<th scope="col" class="column-format"><?php _e( 'Type', 'backupwordpress' ); ?></th>
-					<th scope="col" class="column-format"><?php _e( 'Status', 'backupwordpress' ); ?></th>
-				</tr>
+			<tr>
+				<th></th>
+				<th scope="col"><?php _e( 'Name', 'backupwordpress' ); ?></th>
+				<th scope="col" class="column-format"><?php _e( 'Size', 'backupwordpress' ); ?></th>
+				<th scope="col" class="column-format"><?php _e( 'Permissions', 'backupwordpress' ); ?></th>
+				<th scope="col" class="column-format"><?php _e( 'Type', 'backupwordpress' ); ?></th>
+				<th scope="col" class="column-format"><?php _e( 'Status', 'backupwordpress' ); ?></th>
+			</tr>
 
-				<tr>
+			<tr>
 
-					<th scope="row">
-						<div class="dashicons dashicons-admin-home"></div>
-					</th>
+				<th scope="row">
+					<div class="dashicons dashicons-admin-home"></div>
+				</th>
 
-					<th scope="col">
+				<th scope="col">
 
-						<?php if ( $schedule->backup->get_root() !== $directory ) { ?>
+					<?php if ( $schedule->backup->get_root() !== $directory ) { ?>
 
-							<a href="<?php echo remove_query_arg( 'hmbkp_directory_browse' ); ?>"><?php echo esc_html( $schedule->backup->get_root() ); ?></a> <code>/</code>
+						<a href="<?php echo remove_query_arg( 'hmbkp_directory_browse' ); ?>"><?php echo esc_html( $schedule->backup->get_root() ); ?></a>
+						<code>/</code>
 
-							<?php $parents = array_filter( explode( '/', str_replace( trailingslashit( $schedule->backup->get_root() ), '', trailingslashit( dirname( $directory ) ) ) ) );
+						<?php $parents = array_filter( explode( '/', str_replace( trailingslashit( $schedule->backup->get_root() ), '', trailingslashit( dirname( $directory ) ) ) ) );
 
-							foreach ( $parents as $directory_basename ) { ?>
+						foreach ( $parents as $directory_basename ) { ?>
 
-								<a href="<?php echo add_query_arg( 'hmbkp_directory_browse', urlencode( substr( $directory, 0, strpos( $directory, $directory_basename ) ) . $directory_basename ) ); ?>"><?php echo esc_html( $directory_basename ); ?></a> <code>/</code>
-
-							<?php } ?>
-
-							<?php echo esc_html( basename( $directory ) ); ?>
-
-						<?php } else { ?>
-
-							<?php echo esc_html( $schedule->backup->get_root() ); ?>
+							<a href="<?php echo add_query_arg( 'hmbkp_directory_browse', urlencode( substr( $directory, 0, strpos( $directory, $directory_basename ) ) . $directory_basename ) ); ?>"><?php echo esc_html( $directory_basename ); ?></a>
+							<code>/</code>
 
 						<?php } ?>
 
-					</th>
+						<?php echo esc_html( basename( $directory ) ); ?>
 
-					<td class="column-filesize">
+					<?php } else { ?>
 
-						<?php if ( $schedule->is_site_size_being_calculated() ) { ?>
+						<?php echo esc_html( $schedule->backup->get_root() ); ?>
+
+					<?php } ?>
+
+				</th>
+
+				<td class="column-filesize">
+
+					<?php if ( $schedule->is_site_size_being_calculated() ) { ?>
+
+						<span class="spinner"></span>
+
+					<?php } else {
+
+						$root = new SplFileInfo( $schedule->backup->get_root() );
+
+						$size = $schedule->filesize( $root );
+
+						if ( $size !== false ) {
+
+							$size = size_format( $size );
+
+							if ( ! $size ) {
+								$size = '0 B';
+							} ?>
+
+							<code>
+
+								<?php echo esc_html( $size ); ?>
+
+								<a class="dashicons dashicons-update"
+								   href="<?php echo wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize', urlencode( $schedule->backup->get_root() ) ), 'hmbkp-recalculate_directory_filesize' ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
+
+							</code>
+
+
+						<?php } ?>
+
+					<?php } ?>
+
+				<td>
+					<?php echo esc_html( substr( sprintf( '%o', fileperms( $schedule->backup->get_root() ) ), - 4 ) ); ?>
+				</td>
+
+				<td>
+
+					<?php if ( is_link( $schedule->backup->get_root() ) ) {
+
+						_e( 'Symlink', 'backupwordpress' );
+
+					} elseif ( is_dir( $schedule->backup->get_root() ) ) {
+
+						_e( 'Folder', 'backupwordpress' );
+
+					} ?>
+
+				</td>
+
+				<td></td>
+
+			</tr>
+
+			</thead>
+
+			<tbody>
+
+			<?php foreach ( $files as $size => $file ) {
+
+				$is_excluded = $is_unreadable = false;
+
+				// Check if the file is excluded
+				if ( $exclude_string && preg_match( '(' . $exclude_string . ')', str_ireplace( trailingslashit( $schedule->backup->get_root() ), '', HM\BackUpWordPress\Backup::conform_dir( $file->getPathname() ) ) ) ) {
+					$is_excluded = true;
+				}
+
+				// Skip unreadable files
+				if ( ! @realpath( $file->getPathname() ) || ! $file->isReadable() ) {
+					$is_unreadable = true;
+				} ?>
+
+				<tr>
+
+					<td>
+
+						<?php if ( $is_unreadable ) { ?>
+
+							<div class="dashicons dashicons-dismiss"></div>
+
+						<?php } elseif ( $file->isFile() ) { ?>
+
+							<div class="dashicons dashicons-media-default"></div>
+
+						<?php } elseif ( $file->isDir() ) { ?>
+
+							<div class="dashicons dashicons-portfolio"></div>
+
+						<?php } ?>
+
+					</td>
+
+					<td>
+
+						<?php if ( $is_unreadable ) { ?>
+
+							<code class="strikethrough"
+							      title="<?php echo esc_attr( $file->getRealPath() ); ?>"><?php echo esc_html( $file->getBasename() ); ?></code>
+
+						<?php } elseif ( $file->isFile() ) { ?>
+
+							<code
+								title="<?php echo esc_attr( $file->getRealPath() ); ?>"><?php echo esc_html( $file->getBasename() ); ?></code>
+
+						<?php } elseif ( $file->isDir() ) { ?>
+
+							<code title="<?php echo esc_attr( $file->getRealPath() ); ?>"><a
+									href="<?php echo add_query_arg( 'hmbkp_directory_browse', urlencode( $file->getPathname() ) ); ?>"><?php echo esc_html( $file->getBasename() ); ?></a></code>
+
+						<?php } ?>
+
+					</td>
+
+					<td class="column-format column-filesize">
+
+						<?php if ( $file->isDir() && $schedule->is_site_size_being_calculated() ) { ?>
 
 							<span class="spinner"></span>
 
 						<?php } else {
 
-							$root = new SplFileInfo( $schedule->backup->get_root() );
+							$size = $schedule->filesize( $file );
 
-							$size = $schedule->filesize( $root );
-
-							if ( $size !== false ) {
+							if ( false !== $size ) {
 
 								$size = size_format( $size );
 
@@ -155,183 +273,83 @@
 
 									<?php echo esc_html( $size ); ?>
 
-									<a class="dashicons dashicons-update" href="<?php echo wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize', urlencode( $schedule->backup->get_root() ) ), 'hmbkp-recalculate_directory_filesize' ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
+									<?php if ( $file->isDir() ) { ?>
+
+										<a title="<?php _e( 'Recalculate the size of this directory', 'backupwordpress' ); ?>"
+										   class="dashicons dashicons-update"
+										   href="<?php echo wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize', urlencode( $file->getPathname() ) ), 'hmbkp-recalculate_directory_filesize' ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
+
+									<?php } ?>
 
 								</code>
 
 
-							<?php } ?>
+							<?php } else { ?>
 
-						<?php } ?>
+								<code>--</code>
+
+							<?php }
+						} ?>
+
+					</td>
 
 					<td>
-						<?php echo esc_html( substr( sprintf( '%o', fileperms( $schedule->backup->get_root() ) ), -4 ) ); ?>
+						<?php echo esc_html( substr( sprintf( '%o', $file->getPerms() ), - 4 ) ); ?>
 					</td>
 
 					<td>
 
-						<?php if ( is_link( $schedule->backup->get_root() ) ) {
+						<?php if ( $file->isLink() ) { ?>
 
-							_e( 'Symlink', 'backupwordpress' );
+							<span
+								title="<?php echo esc_attr( $file->GetRealPath() ); ?>"><?php _e( 'Symlink', 'backupwordpress' ); ?></span>
 
-						} elseif ( is_dir( $schedule->backup->get_root() ) ) {
+						<?php } elseif ( $file->isDir() ) {
 
 							_e( 'Folder', 'backupwordpress' );
+
+						} else {
+
+							_e( 'File', 'backupwordpress' );
 
 						} ?>
 
 					</td>
 
-					<td></td>
+					<td class="column-format">
+
+						<?php if ( $is_unreadable ) { ?>
+
+							<strong
+								title="<?php _e( 'Unreadable files won\'t be backed up.', 'backupwordpress' ); ?>"><?php _e( 'Unreadable', 'backupwordpress' ); ?></strong>
+
+						<?php } elseif ( $is_excluded ) { ?>
+
+							<strong><?php _e( 'Excluded', 'backupwordpress' ); ?></strong>
+
+						<?php } else {
+
+							$exclude_path = $file->getPathname();
+
+							// Excluded directories need to be trailingslashed
+							if ( $file->isDir() ) {
+								$exclude_path = trailingslashit( $file->getPathname() );
+							} ?>
+
+							<a href="<?php echo wp_nonce_url( add_query_arg( array(
+								'hmbkp_schedule_id' => $schedule->get_id(),
+								'action' => 'hmbkp_add_exclude_rule',
+								'hmbkp_exclude_pathname' => urlencode( $exclude_path )
+							), admin_url( 'admin-post.php' ) ), 'hmbkp-add-exclude-rule', 'hmbkp-add-exclude-rule-nonce' ); ?>"
+							   class="button-secondary"><?php _e( 'Exclude &rarr;', 'backupwordpress' ); ?></a>
+
+						<?php } ?>
+
+					</td>
 
 				</tr>
 
-			</thead>
-
-			<tbody>
-
-				<?php foreach ( $files as $size => $file ) {
-
-					$is_excluded = $is_unreadable = false;
-
-					// Check if the file is excluded
-					if ( $exclude_string && preg_match( '(' . $exclude_string . ')', str_ireplace( trailingslashit( $schedule->backup->get_root() ), '', HM\BackUpWordPress\Backup::conform_dir( $file->getPathname() ) ) ) ) {
-						$is_excluded = true;
-					}
-
-					// Skip unreadable files
-					if ( ! @realpath( $file->getPathname() ) || ! $file->isReadable() ) {
-						$is_unreadable = true;
-					} ?>
-
-					<tr>
-
-						<td>
-
-							<?php if ( $is_unreadable ) { ?>
-
-								<div class="dashicons dashicons-dismiss"></div>
-
-							<?php } elseif ( $file->isFile() ) { ?>
-
-								<div class="dashicons dashicons-media-default"></div>
-
-							<?php } elseif ( $file->isDir() ) { ?>
-
-								<div class="dashicons dashicons-portfolio"></div>
-
-							<?php } ?>
-
-						</td>
-
-						<td>
-
-							<?php if ( $is_unreadable ) { ?>
-
-								<code class="strikethrough" title="<?php echo esc_attr( $file->getRealPath() ); ?>"><?php echo esc_html( $file->getBasename() ); ?></code>
-
-							<?php } elseif ( $file->isFile() ) { ?>
-
-								<code title="<?php echo esc_attr( $file->getRealPath() ); ?>"><?php echo esc_html( $file->getBasename() ); ?></code>
-
-							<?php } elseif ( $file->isDir() ) { ?>
-
-								<code title="<?php echo esc_attr( $file->getRealPath() ); ?>"><a href="<?php echo add_query_arg( 'hmbkp_directory_browse', urlencode( $file->getPathname() ) ); ?>"><?php echo esc_html( $file->getBasename() ); ?></a></code>
-
-							<?php } ?>
-
-						</td>
-
-						<td class="column-format column-filesize">
-
-							<?php if ( $file->isDir() && $schedule->is_site_size_being_calculated() ) { ?>
-
-								<span class="spinner"></span>
-
-							<?php } else {
-
-								$size = $schedule->filesize( $file );
-
-								if ( false !== $size ) {
-
-									$size = size_format( $size );
-
-									if ( ! $size ) {
-										$size = '0 B';
-									} ?>
-
-									<code>
-
-										<?php echo esc_html( $size ); ?>
-
-										<?php if ( $file->isDir() ) { ?>
-
-											<a title="<?php _e( 'Recalculate the size of this directory', 'backupwordpress' ); ?>" class="dashicons dashicons-update" href="<?php echo wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize', urlencode( $file->getPathname() ) ), 'hmbkp-recalculate_directory_filesize' ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
-
-										<?php }  ?>
-
-									</code>
-
-
-								<?php } else { ?>
-
-									<code>--</code>
-
-								<?php }
-							} ?>
-
-						</td>
-
-						<td>
-							<?php echo esc_html( substr( sprintf( '%o', $file->getPerms() ), -4 ) ); ?>
-						</td>
-
-						<td>
-
-							<?php if ( $file->isLink() ) { ?>
-
-								<span title="<?php echo esc_attr( $file->GetRealPath() ); ?>"><?php _e( 'Symlink', 'backupwordpress' ); ?></span>
-
-							<?php } elseif ( $file->isDir() ) {
-
-								_e( 'Folder', 'backupwordpress' );
-
-							} else {
-
-								_e( 'File', 'backupwordpress' );
-
-							} ?>
-
-						</td>
-
-						<td class="column-format">
-
-							<?php if ( $is_unreadable ) { ?>
-
-								<strong title="<?php _e( 'Unreadable files won\'t be backed up.', 'backupwordpress' ); ?>"><?php _e( 'Unreadable', 'backupwordpress' ); ?></strong>
-
-							<?php } elseif ( $is_excluded ) { ?>
-
-								<strong><?php _e( 'Excluded', 'backupwordpress' ); ?></strong>
-
-							<?php } else {
-
-								$exclude_path = $file->getPathname();
-
-								// Excluded directories need to be trailingslashed
-								if ( $file->isDir() ) {
-									$exclude_path = trailingslashit( $file->getPathname() );
-								} ?>
-
-								<a href="<?php echo wp_nonce_url( add_query_arg( array( 'hmbkp_schedule_id' => $schedule->get_id(), 'action' => 'hmbkp_add_exclude_rule', 'hmbkp_exclude_pathname' => urlencode( $exclude_path ) ), admin_url( 'admin-post.php' ) ), 'hmbkp-add-exclude-rule', 'hmbkp-add-exclude-rule-nonce' ); ?>" class="button-secondary"><?php _e( 'Exclude &rarr;', 'backupwordpress' ); ?></a>
-
-							<?php } ?>
-
-						</td>
-
-					</tr>
-
-				<?php } ?>
+			<?php } ?>
 
 			</tbody>
 
@@ -342,5 +360,6 @@
 </div>
 
 <p class="submit">
-	<a href="<?php echo esc_url( hmbkp_get_settings_url() ) ?>" class="button-primary"><?php _e( 'Done', 'backupwordpress' ); ?></a>
+	<a href="<?php echo esc_url( hmbkp_get_settings_url() ) ?>"
+	   class="button-primary"><?php _e( 'Done', 'backupwordpress' ); ?></a>
 </p>

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -6,8 +6,8 @@
 			<?php _e( 'Currently Excluded', 'backupwordpress' ); ?>
 		</h3>
 
-		<p><?php _e( 'We automatically detect and ignore common VCS folders and other backup plugin folders.', 'backupwordpress' ); ?></p>
-		
+		<p><?php _e( 'We automatically detect and ignore common <abbr title="Version Control Systems">VCS</abbr> folders and other backup plugin folders.', 'backupwordpress' ); ?></p>
+
 		<table class="widefat">
 
 			<tbody>

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -2,13 +2,17 @@
 
 	<?php if ( $schedule->get_excludes() ) : ?>
 
-		<h3><?php _e( 'Currently Excluded', 'backupwordpress' ); ?></h3>
+		<h3>
+			<?php _e( 'Currently Excluded', 'backupwordpress' ); ?>
+		</h3>
 
+		<p><?php _e( 'We automatically detect and ignore common VCS folders and other backup plugin folders.', 'backupwordpress' ); ?></p>
+		
 		<table class="widefat">
 
 			<tbody>
 
-			<?php foreach ( $schedule->get_excludes() as $key => $exclude ) :
+			<?php foreach ( array_diff( $schedule->get_excludes(), $schedule->backup->default_excludes() ) as $key => $exclude ) :
 
 				$exclude_path = new SplFileInfo( trailingslashit( $schedule->backup->get_root() ) . ltrim( str_ireplace( $schedule->backup->get_root(), '', $exclude ), '/' ) ); ?>
 

--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -142,6 +142,8 @@ final class Plugin {
 	 */
 	protected function includes() {
 
+		require_once( HMBKP_PLUGIN_PATH . 'vendor/autoload.php' );
+
 		require_once( HMBKP_PLUGIN_PATH . 'classes/class-notices.php' );
 
 		// Load the admin menu

--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -157,8 +157,10 @@ namespace HM\BackUpWordPress {
 		protected $action_callback = '';
 
 		protected $default_excludes = array(
+			'.git/',
+			'.svn/',
 			'.DS_Store',
-			'.idea',
+			'.idea/',
 			'backup-*',
 			'backwpup-*',
 			'updraft',

--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -1182,7 +1182,7 @@ namespace HM\BackUpWordPress {
 
 			$finder = new Finder();
 			$finder->followLinks();
-			$finder->ignoreDotFiles( true );
+			$finder->ignoreDotFiles( false );
 			$finder->ignoreUnreadableDirs();
 
 			foreach ( $this->default_excludes as $exclude ) {

--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -185,6 +185,7 @@ namespace HM\BackUpWordPress {
 		 * Check whether safe mode is active or not
 		 *
 		 * @param string $ini_get_callback
+		 *
 		 * @return bool
 		 */
 		public static function is_safe_mode_active( $ini_get_callback = 'ini_get' ) {
@@ -232,7 +233,11 @@ namespace HM\BackUpWordPress {
 
 		protected static function is_function_disabled( $ini_setting ) {
 
-			if ( array_intersect( array( 'shell_exec', 'escapeshellarg', 'escapeshellcmd' ), array_map( 'trim', explode( ',', @ini_get( $ini_setting ) ) ) ) ) {
+			if ( array_intersect( array(
+				'shell_exec',
+				'escapeshellarg',
+				'escapeshellcmd'
+			), array_map( 'trim', explode( ',', @ini_get( $ini_setting ) ) ) ) ) {
 				return false;
 			}
 
@@ -266,7 +271,8 @@ namespace HM\BackUpWordPress {
 		 * Sanitize a directory path
 		 *
 		 * @param string $dir
-		 * @param bool   $recursive
+		 * @param bool $recursive
+		 *
 		 * @return string
 		 */
 		public static function conform_dir( $dir, $recursive = false ) {
@@ -355,7 +361,15 @@ namespace HM\BackUpWordPress {
 		public function get_archive_filename() {
 
 			if ( empty( $this->archive_filename ) ) {
-				$this->set_archive_filename( implode( '-', array( sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), 'backup', current_time( 'Y-m-d-H-i-s' ) ) ) . '.zip' );
+				$this->set_archive_filename( implode( '-', array(
+						sanitize_title( str_ireplace( array(
+							'http://',
+							'https://',
+							'www'
+						), '', home_url() ) ),
+						'backup',
+						current_time( 'Y-m-d-H-i-s' )
+					) ) . '.zip' );
 			}
 
 			return $this->archive_filename;
@@ -366,6 +380,7 @@ namespace HM\BackUpWordPress {
 		 * Set the filename of the archive file
 		 *
 		 * @param string $filename
+		 *
 		 * @return \WP_Error|null
 		 */
 		public function set_archive_filename( $filename ) {
@@ -410,6 +425,7 @@ namespace HM\BackUpWordPress {
 		 * Set the filename of the database dump file
 		 *
 		 * @param string $filename
+		 *
 		 * @return \WP_Error|null
 		 */
 		public function set_database_dump_filename( $filename ) {
@@ -447,6 +463,7 @@ namespace HM\BackUpWordPress {
 		 * Set the root directory to backup from
 		 *
 		 * @param string $path
+		 *
 		 * @return \WP_Error|null
 		 */
 		public function set_root( $path ) {
@@ -472,6 +489,7 @@ namespace HM\BackUpWordPress {
 		 * Set the filepath for the existing archive
 		 *
 		 * @param string $existing_archive_filepath
+		 *
 		 * @return null
 		 */
 		public function set_existing_archive_filepath( $existing_archive_filepath ) {
@@ -526,6 +544,7 @@ namespace HM\BackUpWordPress {
 		 * $type must be one of complete, database or file
 		 *
 		 * @param string $type
+		 *
 		 * @return \WP_Error|null
 		 */
 		public function set_type( $type ) {
@@ -685,7 +704,8 @@ namespace HM\BackUpWordPress {
 		 * Both the action and the instance on Backup are then passed to the callback function
 		 *
 		 * @see set_action_callback
-		 * @param string $action     The event to fire
+		 *
+		 * @param string $action The event to fire
 		 */
 		protected function do_action( $action ) {
 
@@ -714,11 +734,12 @@ namespace HM\BackUpWordPress {
 		 *
 		 * @see do_action
 		 * @see /do_action
+		 *
 		 * @param callable $callback The function or method to be called
-		 * @param int $priority      The priority of the callback
+		 * @param int $priority The priority of the callback
 		 */
 		public function set_action_callback( $callback, $priority = 10 ) {
-			$this->action_callback[$priority][] = $callback;
+			$this->action_callback[ $priority ][] = $callback;
 		}
 
 		/**
@@ -1020,13 +1041,11 @@ namespace HM\BackUpWordPress {
 
 					if ( $file->isDir() ) {
 						$zip->addEmptyDir( trailingslashit( str_ireplace( trailingslashit( $this->get_root() ), '', self::conform_dir( $file->getPathname() ) ) ) );
-					}
-
-					elseif ( $file->isFile() ) {
+					} elseif ( $file->isFile() ) {
 						$zip->addFile( $file->getPathname(), str_ireplace( trailingslashit( $this->get_root() ), '', self::conform_dir( $file->getPathname() ) ) );
 					}
 
-					if ( ++$files_added % 500 === 0 ) {
+					if ( ++ $files_added % 500 === 0 ) {
 						if ( ! $zip->close() || ! $zip->open( $this->get_archive_filepath(), \ZIPARCHIVE::CREATE ) ) {
 							return;
 						}
@@ -1325,7 +1344,7 @@ namespace HM\BackUpWordPress {
 		 * Set the excludes, expects and array
 		 *
 		 * @param  Array $excludes
-		 * @param Bool   $append
+		 * @param Bool $append
 		 */
 		public function set_excludes( $excludes, $append = false ) {
 
@@ -1347,7 +1366,8 @@ namespace HM\BackUpWordPress {
 		 * Takes the exclude rules and formats them for use with either
 		 * the shell zip command or pclzip
 		 *
-		 * @param string $context. (default: 'zip')
+		 * @param string $context . (default: 'zip')
+		 *
 		 * @return string
 		 */
 		public function exclude_string( $context = 'zip' ) {
@@ -1362,8 +1382,7 @@ namespace HM\BackUpWordPress {
 				$separator = ' -x ';
 
 				// The PclZip fallback library
-			}
-			elseif ( $context === 'regex' ) {
+			} elseif ( $context === 'regex' ) {
 				$wildcard  = '([\s\S]*?)';
 				$separator = '|';
 			}
@@ -1377,14 +1396,10 @@ namespace HM\BackUpWordPress {
 				// Files don't end with /
 				if ( ! in_array( substr( $rule, - 1 ), array( '\\', '/' ) ) ) {
 					$file = true;
-				}
-
-				// If rule starts with a / then treat as absolute path
+				} // If rule starts with a / then treat as absolute path
 				elseif ( in_array( substr( $rule, 0, 1 ), array( '\\', '/' ) ) ) {
 					$absolute = true;
-				}
-
-				// Otherwise treat as dir fragment
+				} // Otherwise treat as dir fragment
 				else {
 					$fragment = true;
 				}
@@ -1444,6 +1459,7 @@ namespace HM\BackUpWordPress {
 		 * Add backquotes to tables and db-names in SQL queries. Taken from phpMyAdmin.
 		 *
 		 * @param mixed $a_name
+		 *
 		 * @return array|string
 		 */
 		private function sql_backquote( $a_name ) {
@@ -1457,7 +1473,7 @@ namespace HM\BackUpWordPress {
 					reset( $a_name );
 
 					while ( list( $key, $val ) = each( $a_name ) ) {
-						$result[$key] = '`' . $val . '`';
+						$result[ $key ] = '`' . $val . '`';
 					}
 
 					return $result;
@@ -1526,7 +1542,7 @@ namespace HM\BackUpWordPress {
 			$result = mysql_query( $query, $this->db );
 
 			$fields_cnt = 0;
-			$rows_cnt = 0;
+			$rows_cnt   = 0;
 
 			if ( $result ) {
 				$fields_cnt = mysql_num_fields( $result );
@@ -1545,13 +1561,13 @@ namespace HM\BackUpWordPress {
 			// Checks whether the field is an integer or not
 			for ( $j = 0; $j < $fields_cnt; $j ++ ) {
 
-				$field_set[$j] = $this->sql_backquote( mysql_field_name( $result, $j ) );
-				$type          = mysql_field_type( $result, $j );
+				$field_set[ $j ] = $this->sql_backquote( mysql_field_name( $result, $j ) );
+				$type            = mysql_field_type( $result, $j );
 
 				if ( $type === 'tinyint' || $type === 'smallint' || $type === 'mediumint' || $type === 'int' || $type === 'bigint' ) {
-					$field_num[$j] = true;
+					$field_num[ $j ] = true;
 				} else {
-					$field_num[$j] = false;
+					$field_num[ $j ] = false;
 				}
 
 			}
@@ -1572,17 +1588,16 @@ namespace HM\BackUpWordPress {
 				// build the statement
 				for ( $j = 0; $j < $fields_cnt; $j ++ ) {
 
-					if ( ! isset( $row[$j] ) ) {
+					if ( ! isset( $row[ $j ] ) ) {
 						$values[] = 'NULL';
 
-					}
-					elseif ( $row[$j] === '0' || $row[$j] !== '' ) {
+					} elseif ( $row[ $j ] === '0' || $row[ $j ] !== '' ) {
 
 						// a number
-						if ( $field_num[$j] ) {
-							$values[] = $row[$j];
+						if ( $field_num[ $j ] ) {
+							$values[] = $row[ $j ];
 						} else {
-							$values[] = "'" . str_replace( $search, $replace, $this->sql_addslashes( $row[$j] ) ) . "'";
+							$values[] = "'" . str_replace( $search, $replace, $this->sql_addslashes( $row[ $j ] ) ) . "'";
 						}
 
 					} else {
@@ -1624,7 +1639,8 @@ namespace HM\BackUpWordPress {
 		 * Taken from phpMyAdmin.
 		 *
 		 * @param string $a_string (default: '')
-		 * @param bool   $is_like (default: false)
+		 * @param bool $is_like (default: false)
+		 *
 		 * @return mixed
 		 */
 		private function sql_addslashes( $a_string = '', $is_like = false ) {
@@ -1644,6 +1660,7 @@ namespace HM\BackUpWordPress {
 		 * Write the SQL file
 		 *
 		 * @param string $sql
+		 *
 		 * @return null|boolean
 		 */
 		private function write_sql( $sql ) {
@@ -1676,7 +1693,7 @@ namespace HM\BackUpWordPress {
 		public function get_errors( $context = null ) {
 
 			if ( ! empty( $context ) ) {
-				return isset( $this->errors[$context] ) ? $this->errors[$context] : array();
+				return isset( $this->errors[ $context ] ) ? $this->errors[ $context ] : array();
 			}
 
 			return $this->errors;
@@ -1687,7 +1704,7 @@ namespace HM\BackUpWordPress {
 		 * Add an error to the errors stack
 		 *
 		 * @param string $context
-		 * @param mixed  $error
+		 * @param mixed $error
 		 */
 		public function error( $context, $error ) {
 
@@ -1697,7 +1714,7 @@ namespace HM\BackUpWordPress {
 
 			$this->do_action( 'hmbkp_error' );
 
-			$this->errors[$context][$_key = md5( implode( ':', (array) $error ) )] = $error;
+			$this->errors[ $context ][ $_key = md5( implode( ':', (array) $error ) ) ] = $error;
 
 		}
 
@@ -1721,10 +1738,8 @@ namespace HM\BackUpWordPress {
 			}
 
 			if ( $context ) {
-				unset( $this->errors[$context] );
-			}
-
-			else {
+				unset( $this->errors[ $context ] );
+			} else {
 				$this->errors = array();
 			}
 
@@ -1737,7 +1752,7 @@ namespace HM\BackUpWordPress {
 		public function get_warnings( $context = null ) {
 
 			if ( ! empty( $context ) ) {
-				return isset( $this->warnings[$context] ) ? $this->warnings[$context] : array();
+				return isset( $this->warnings[ $context ] ) ? $this->warnings[ $context ] : array();
 			}
 
 			return $this->warnings;
@@ -1748,7 +1763,7 @@ namespace HM\BackUpWordPress {
 		 * Add an warning to the warnings stack
 		 *
 		 * @param string $context
-		 * @param mixed  $warning
+		 * @param mixed $warning
 		 */
 		private function warning( $context, $warning ) {
 
@@ -1758,7 +1773,7 @@ namespace HM\BackUpWordPress {
 
 			$this->do_action( 'hmbkp_warning' );
 
-			$this->warnings[$context][$_key = md5( implode( ':', (array) $warning ) )] = $warning;
+			$this->warnings[ $context ][ $_key = md5( implode( ':', (array) $warning ) ) ] = $warning;
 
 		}
 
@@ -1766,6 +1781,7 @@ namespace HM\BackUpWordPress {
 		 * Custom error handler for catching php errors
 		 *
 		 * @param $type
+		 *
 		 * @return bool
 		 */
 		public function error_handler( $type ) {
@@ -1799,7 +1815,8 @@ namespace {
 	 * of the zip
 	 *
 	 * @param string $event
-	 * @param array  $file
+	 * @param array $file
+	 *
 	 * @return bool
 	 */
 	function hmbkp_pclzip_callback( $event, $file ) {
@@ -1809,9 +1826,7 @@ namespace {
 		// Don't try to add unreadable files.
 		if ( ! is_readable( $file['filename'] ) || ! file_exists( $file['filename'] ) ) {
 			return false;
-		}
-
-		// Match everything else past the exclude list
+		} // Match everything else past the exclude list
 		elseif ( $_hmbkp_exclude_string && preg_match( '(' . $_hmbkp_exclude_string . ')', $file['stored_filename'] ) ) {
 			return false;
 		}

--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -1190,10 +1190,10 @@ namespace HM\BackUpWordPress {
 			}
 
 			foreach ( $finder->in( $this->get_root() ) as $entry ) {
-				$found[] = $entry->getRealPath();
+				$this->files[] = $entry;
 			}
 
-			return $found;
+			return $this->files;
 
 		}
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace HM\BackUpWordPress;
+
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -70,9 +71,22 @@ class Scheduled_Backup {
 		$this->backup = new Backup();
 
 		// Set the archive filename to site name + schedule slug + date
-		$this->backup->set_archive_filename( implode( '-', array( sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), $this->get_id(), $this->get_type(), current_time( 'Y-m-d-H-i-s' ) ) ) . '.zip' );
+		$this->backup->set_archive_filename( implode( '-', array(
+				sanitize_title( str_ireplace( array(
+					'http://',
+					'https://',
+					'www'
+				), '', home_url() ) ),
+				$this->get_id(),
+				$this->get_type(),
+				current_time( 'Y-m-d-H-i-s' )
+			) ) . '.zip' );
 
-		$this->backup->set_database_dump_filename( implode( '-', array( 'database', sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ), $this->get_id() ) ) . '.sql' );
+		$this->backup->set_database_dump_filename( implode( '-', array(
+				'database',
+				sanitize_title( str_ireplace( array( 'http://', 'https://', 'www' ), '', home_url() ) ),
+				$this->get_id()
+			) ) . '.sql' );
 
 		$this->backup->set_type( $this->get_type() );
 		$this->backup->set_excludes( $this->backup->default_excludes(), true );
@@ -414,7 +428,7 @@ class Scheduled_Backup {
 
 				// If there is already a file with exactly the same filesize then let's keep increasing the filesize of this one until we don't have a clash
 				while ( array_key_exists( $filesize, $files_with_size ) ) {
-					$filesize++;
+					$filesize ++;
 				}
 
 				$files_with_size[ $filesize ] = $entry;
@@ -495,9 +509,10 @@ class Scheduled_Backup {
 	 * If $file is a file then just return the result of `filesize()`.
 	 * If $file is a directory then schedule a recursive filesize scan.
 	 *
-	 * @param \SplFileInfo $file			The file or directory you want to know the size of
-	 * @param bool $skip_excluded_files	Skip excluded files when calculating a directories total size
-	 * @return int 						The total of the file or directory
+	 * @param \SplFileInfo $file The file or directory you want to know the size of
+	 * @param bool $skip_excluded_files Skip excluded files when calculating a directories total size
+	 *
+	 * @return int                        The total of the file or directory
 	 */
 	public function filesize( \SplFileInfo $file, $skip_excluded_files = false ) {
 
@@ -535,7 +550,7 @@ class Scheduled_Backup {
 			}
 
 			$current_pathname = trailingslashit( $file->getPathname() );
-			$root = trailingslashit( $this->backup->get_root() );
+			$root             = trailingslashit( $this->backup->get_root() );
 
 			foreach ( $directory_sizes as $path => $size ) {
 
@@ -844,6 +859,7 @@ class Scheduled_Backup {
 	 * Set the status of the running backup
 	 *
 	 * @param string $message
+	 *
 	 * @return null
 	 */
 	public function set_status( $message ) {
@@ -1018,7 +1034,7 @@ class Scheduled_Backup {
 
 		$duration = 'Unknown';
 
-		if ( ! isset( $this->options['duration_total'] ) || ! isset( $this->options['backup_run_count'] )  ) {
+		if ( ! isset( $this->options['duration_total'] ) || ! isset( $this->options['backup_run_count'] ) ) {
 			return $duration;
 		}
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -410,7 +410,7 @@ class Scheduled_Backup {
 		) );
 
 		$finder = new Finder();
-		$finder->ignoreDotFiles( true );
+		$finder->ignoreDotFiles( false );
 		$finder->ignoreUnreadableDirs();
 		$finder->followLinks();
 		$finder->depth( '== 0' );

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -332,7 +332,7 @@ class Scheduled_Backup {
 
 			$root = new \SplFileInfo( $this->backup->get_root() );
 
-			$size += $this->filesize( $root, true );
+			$size += $this->filesize( $root );
 
 		}
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -1181,7 +1181,11 @@ class Scheduled_Backup {
 
 		$backupwp_folders = $this->find_backup_folders( 'backwpup-', $hmn_upload_dir['path'] );
 
-		if ( ! empty( $backupwp_folders ) ) {
+		$generic_backup = $this->find_backup_folders( 'backup-', WP_CONTENT_DIR );
+
+		$found = array_merge( $backupwp_folders, $generic_backup );
+
+		if ( ! empty( $found ) ) {
 			foreach ( $backupwp_folders as $path ) {
 				$excluded[] = $path;
 			}
@@ -1195,6 +1199,8 @@ class Scheduled_Backup {
 			'pb_backupbuddy' => trailingslashit( $hmn_upload_dir['path'] ) . trailingslashit( 'pb_backupbuddy' ),
 			'wpdbmanager'    => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'backup-db' ),
 			'supercache'     => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'cache' ),
+			'envato'         => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'Envato-backups' ),
+			'managewp'         => trailingslashit( WP_CONTENT_DIR ) . trailingslashit( 'managewp' ),
 		);
 
 		foreach ( $blacklisted as $key => $path ) {

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -315,7 +315,7 @@ class Scheduled_Backup {
 
 		$size = 0;
 
-		// Don't include database if file only
+		// Include database size except for file only schedule.
 		if ( 'file' !== $this->get_type() ) {
 
 			global $wpdb;
@@ -327,7 +327,7 @@ class Scheduled_Backup {
 			}
 		}
 
-		// Don't include files if database only
+		// Include total size of dirs/files except for database only schedule.
 		if ( 'database' !== $this->get_type() ) {
 
 			$root = new \SplFileInfo( $this->backup->get_root() );
@@ -547,6 +547,10 @@ class Scheduled_Backup {
 
 				return;
 
+			}
+
+			if ( $this->backup->get_root() === $file->getPathname() ) {
+				return $directory_sizes[ $file->getPathname() ];
 			}
 
 			$current_pathname = trailingslashit( $file->getPathname() );

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -467,8 +467,6 @@ class Scheduled_Backup {
 
 		}
 
-		$directory_sizes[ $this->backup->get_root() ] = filesize( $this->backup->get_root() );
-
 		$files = $this->backup->get_files();
 
 		foreach ( $files as $file ) {
@@ -480,6 +478,9 @@ class Scheduled_Backup {
 			}
 
 		}
+
+		// This will be the total size of the included folders MINUS default excludes.
+		$directory_sizes[ $this->backup->get_root() ] = array_sum( $directory_sizes );
 
 		set_transient( 'hmbkp_directory_filesizes', $directory_sizes, DAY_IN_SECONDS );
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -393,21 +393,7 @@ class Scheduled_Backup {
 			return $this->files;
 		}
 
-		$default_excludes = apply_filters( 'hmbkp_default_excludes', array(
-			'.DS_Store',
-			'.idea',
-			'backup-*',
-			'backwpup-*',
-			'updraft',
-			'backups',
-			'wp-snapshots',
-			'backupbuddy_backups',
-			'pb_backupbuddy',
-			'backup-db',
-			'cache',
-			'Envato-backups',
-			'managewp',
-		) );
+		$default_excludes = $this->backup->default_excludes();
 
 		$finder = new Finder();
 		$finder->ignoreDotFiles( false );

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -56,12 +56,22 @@ class Setup {
 
 		$schedules = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s", 'hmbkp_schedule_%' ) );
 
-		foreach ( array_map( function( $item ){ return ltrim( $item, 'hmbkp_schedule_' ); }, $schedules ) as $item ) {
+		foreach (
+			array_map( function ( $item ) {
+				return ltrim( $item, 'hmbkp_schedule_' );
+			}, $schedules ) as $item
+		) {
 			wp_clear_scheduled_hook( 'hmbkp_schedule_hook', array( 'id' => $item ) );
 		}
 
 		// Delete all transients
-		$transients = array( 'hmbkp_plugin_data', 'hmbkp_directory_filesizes', 'hmbkp_directory_filesize_running', 'timeout_hmbkp_wp_cron_test_beacon', 'hmbkp_wp_cron_test_beacon' );
+		$transients = array(
+			'hmbkp_plugin_data',
+			'hmbkp_directory_filesizes',
+			'hmbkp_directory_filesize_running',
+			'timeout_hmbkp_wp_cron_test_beacon',
+			'hmbkp_wp_cron_test_beacon',
+		);
 
 		array_map( 'delete_transient', $transients );
 

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -68,7 +68,8 @@ class Setup {
 		$transients = array(
 			'hmbkp_plugin_data',
 			'hmbkp_directory_filesizes',
-			'hmbkp_directory_filesize_running',
+			'hmbkp_directory_filesizes_running',
+			'timeout_hmbkp_directory_filesizes_running',
 			'timeout_hmbkp_wp_cron_test_beacon',
 			'hmbkp_wp_cron_test_beacon',
 		);

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -60,6 +60,11 @@ class Setup {
 			wp_clear_scheduled_hook( 'hmbkp_schedule_hook', array( 'id' => $item ) );
 		}
 
+		// Delete all transients
+		$transients = array( 'hmbkp_plugin_data', 'hmbkp_directory_filesizes', 'hmbkp_directory_filesize_running', 'timeout_hmbkp_wp_cron_test_beacon', 'hmbkp_wp_cron_test_beacon' );
+
+		array_map( 'delete_transient', $transients );
+
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
     ],
     "support"    : {
         "issues": "https://github.com/humanmade/backupwordpress/issues"
+    },
+    "require": {
+        "symfony/finder": "~2.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,55 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2ea1baa7f779130da215184917bef586",
+    "hash": "8507202030c5849d31097cd274879371",
     "packages": [
+        {
+            "name": "symfony/finder",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/Finder",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Finder.git",
+                "reference": "16513333bca64186c01609961a2bb1b95b5e1355"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/16513333bca64186c01609961a2bb1b95b5e1355",
+                "reference": "16513333bca64186c01609961a2bb1b95b5e1355",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-03 08:01:59"
+        },
         {
             "name": "symfony/process",
             "version": "v2.6.4",


### PR DESCRIPTION
***Original issue***
There's also a managewp folder we can exclude. Additionally, I don't know what plugin it originated from but I saw a ```backups-*****``` folder, maybe we can catch that too.

***PR Summary***
I took a bit of a deep dive into how we were calculating directory sizes and scanning the filesystem.
I tried to consolidate our different scanning functions to use the Symfony Finder component which provides a layer of abstraction on top of the SPL Iterators.
It will allow us to do more complex "queries" in the future. It also irons out a few bugs in the default PHP Iterators and deals with cross platform inconsistencies. It's compatible with PHP 5.3

Whenever you see a directory size now, it has been calculated without the default excluded folders, for example any `.git` folder will not be taken into account for calculating the size of the folder.

