### PR TITLE
Fix incorrect type error

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -277,12 +277,7 @@ namespace HM\BackUpWordPress {
 		 *
 		 * @return string
 		 */
-		public static function conform_dir( $dir, $recursive = false ) {
-
-			// Assume empty dir is root
-			if ( ! $dir ) {
-				$dir = '/';
-			}
+		public static function conform_dir( $dir = '/', $recursive = false ) {
 
 			// Replace single forward slash (looks like double slash because we have to escape it)
 			$dir = str_replace( '\\', '/', $dir );

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -472,9 +472,9 @@ class Scheduled_Backup {
 		foreach ( $files as $file ) {
 
 			if ( $file->isReadable() ) {
-				$directory_sizes[ Backup::conform_dir( $file ) ] = $file->getSize();
+				$directory_sizes[ Backup::conform_dir( $file->getRealpath() ) ] = $file->getSize();
 			} else {
-				$directory_sizes[ Backup::conform_dir( $file ) ] = 0;
+				$directory_sizes[ Backup::conform_dir( $file->getRealpath() ) ] = 0;
 			}
 
 		}

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -69,9 +69,8 @@ class Setup {
 			'hmbkp_plugin_data',
 			'hmbkp_directory_filesizes',
 			'hmbkp_directory_filesizes_running',
-			'timeout_hmbkp_directory_filesizes_running',
-			'timeout_hmbkp_wp_cron_test_beacon',
 			'hmbkp_wp_cron_test_beacon',
+			'hm_backdrop',
 		);
 
 		array_map( 'delete_transient', $transients );

--- a/functions/core.php
+++ b/functions/core.php
@@ -217,6 +217,22 @@ function hmbkp_update() {
 
 	}
 
+	// Update to 3.1.5
+	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( '3.1.5', get_option( 'hmbkp_plugin_version' ), '>' ) ) {
+
+		// Delete all transients
+		$transients = array(
+			'hmbkp_plugin_data',
+			'hmbkp_directory_filesizes',
+			'hmbkp_directory_filesizes_running',
+			'timeout_hmbkp_directory_filesizes_running',
+			'timeout_hmbkp_wp_cron_test_beacon',
+			'hmbkp_wp_cron_test_beacon',
+		);
+
+		array_map( 'delete_transient', $transients );
+	}
+
 	// Every update
 	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( HM\BackUpWordPress\Plugin::PLUGIN_VERSION, get_option( 'hmbkp_plugin_version' ), '>' ) ) {
 

--- a/functions/core.php
+++ b/functions/core.php
@@ -225,9 +225,8 @@ function hmbkp_update() {
 			'hmbkp_plugin_data',
 			'hmbkp_directory_filesizes',
 			'hmbkp_directory_filesizes_running',
-			'timeout_hmbkp_directory_filesizes_running',
-			'timeout_hmbkp_wp_cron_test_beacon',
 			'hmbkp_wp_cron_test_beacon',
+			'hm_backdrop',
 		);
 
 		array_map( 'delete_transient', $transients );


### PR DESCRIPTION
This fixes a bug where we were trying to use `conform_dir` on an SPL object instead of on a path string.