### PR TITLE
Schedule time format is inconsistent

### DIFF
--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -84,6 +84,8 @@ hmbkp_clear_settings_errors();
 				$start_time = time();
 			} ?>
 
+			<?php $start_date_array = date_parse( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $start_time ) ); ?>
+
 			<tr id="start-day" class="recurring-setting">
 
 				<th scope="row">
@@ -123,7 +125,7 @@ hmbkp_clear_settings_errors();
 				</th>
 
 				<td>
-					<input type="number" min="0" max="31" step="1" id="hmbkp_schedule_start_day_of_month" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_day_of_month]" value="<?php echo esc_attr( date_i18n( 'j', $start_time ) ); ?>">
+					<input type="number" min="0" max="31" step="1" id="hmbkp_schedule_start_day_of_month" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_day_of_month]" value="<?php echo esc_attr( $start_date_array['day'] ); ?>">
 				</td>
 
 			</tr>
@@ -138,16 +140,16 @@ hmbkp_clear_settings_errors();
 
 					<span class="field-group">
 
-						<label for="hmbkp_schedule_start_hours"><input type="number" min="0" max="23" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_hours]" id="hmbkp_schedule_start_hours" value="<?php echo esc_attr( date_i18n( 'G', $start_time ) ); ?>">
+						<label for="hmbkp_schedule_start_hours"><input type="number" min="0" max="23" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_hours]" id="hmbkp_schedule_start_hours" value="<?php echo esc_attr( $start_date_array['hour'] ); ?>">
 
 						<?php _e( 'Hours', 'backupwordpress' ); ?></label>
 
-						<label for="hmbkp_schedule_start_minutes"><input type="number" min="0" max="59" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_minutes]" id="hmbkp_schedule_start_minutes" value="<?php echo esc_attr( (float) date_i18n( 'i', $start_time ) ); ?>">
+						<label for="hmbkp_schedule_start_minutes"><input type="number" min="0" max="59" step="1" name="hmbkp_schedule_recurrence[hmbkp_schedule_start_minutes]" id="hmbkp_schedule_start_minutes" value="<?php echo esc_attr( $start_date_array['minute'] ); ?>">
 
 						<?php _e( 'Minutes', 'backupwordpress' ); ?></label>
 
 					</span>
-
+<p class="descriprion"><strong><?php esc_html_e( 'Please use 24 hour format for hours', 'backupwordpress' ); ?></strong></p>
 					<p class="twice-js description<?php if ( $schedule->get_reoccurrence() !== 'hmbkp_fortnightly' ) { ?> hidden<?php } ?>"><?php _e( 'The second backup will run 12 hours after the first', 'backupwordpress' ); ?></p>
 
 				</td>

--- a/admin/schedule-sentence.php
+++ b/admin/schedule-sentence.php
@@ -148,11 +148,17 @@ if ( ! empty( $services ) && count( $services ) > 1 ) {
 function hmbkp_get_site_size_text( HM\BackUpWordPress\Scheduled_Backup $schedule ) {
 
 	if ( isset( $_GET['hmbkp_add_schedule'] ) ) {
+
 		return '';
-	} elseif (  ( 'database' === $schedule->get_type() ) || $schedule->is_site_size_cached() ) {
+
+	} elseif ( ( 'database' === $schedule->get_type() ) || $schedule->is_site_size_cached() ) {
+
 		return sprintf( '(<code title="' . __( 'Backups will be compressed and should be smaller than this.', 'backupwordpress' ) . '">%s</code>)', esc_attr( $schedule->get_formatted_site_size() ) );
+
 	} else {
-		return sprintf('(<code class="calculating" title="' . __( 'this shouldn\'t take long&hellip;', 'backupwordpress' ) . '">' . __( 'calculating the size of your backup&hellip;', 'backupwordpress' ) . '</code>)');
+
+		return sprintf( '(<code class="calculating" title="' . __( 'this shouldn\'t take long&hellip;', 'backupwordpress' ) . '">' . __( 'calculating the size of your backup&hellip;', 'backupwordpress' ) . '</code>)' );
+
 	}
 
 }

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -173,8 +173,10 @@ add_action( 'admin_init', 'hmbkp_set_server_config_notices' );
  */
 function hmbkp_plugin_row( $plugins ) {
 
+	$menu = is_multisite() ? 'Settings' : 'Tools';
+
 	if ( isset( $plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php'] ) ) {
-		$plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php']['Description'] = str_replace( 'Once activated you\'ll find me under <strong>Tools &rarr; Backups</strong>', 'Find me under <strong><a href="' . esc_url( hmbkp_get_settings_url() ) . '">Tools &rarr; Backups</a></strong>', $plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php']['Description'] );
+		$plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php']['Description'] = str_replace( 'Once activated you\'ll find me under <strong>' . $menu . ' &rarr; Backups</strong>', 'Find me under <strong><a href="' . esc_url( hmbkp_get_settings_url() ) . '">' . $menu . ' &rarr; Backups</a></strong>', $plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php']['Description'] );
 	}
 
 	return $plugins;
@@ -339,11 +341,7 @@ function hmbkp_translated_schedule_title( $slug, $title ) {
 
 function hmbkp_get_settings_url() {
 
-	if ( is_multisite() ) {
-		$url = network_admin_url( 'settings.php?page=' . HMBKP_PLUGIN_SLUG );
-	} else {
-		$url = admin_url( 'tools.php?page=' . HMBKP_PLUGIN_SLUG );
-	}
+	$url = is_multisite() ? self_admin_url( 'settings.php?page=' . HMBKP_PLUGIN_SLUG ) : self_admin_url( 'tools.php?page=' . HMBKP_PLUGIN_SLUG );
 
 	HM\BackUpWordPress\schedules::get_instance()->refresh_schedules();
 


### PR DESCRIPTION
We should adda description and placeholders telling the user that they need to use 24H format, and display the time as such in the sentence.
![screen shot 2015-03-04 at 17 40 52](https://cloud.githubusercontent.com/assets/30460/6489381/c955fca0-c295-11e4-8c75-73cd5cc773ff.png)
