### PR TITLE
Change plugn name to include backup as a keyword

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: BackUpWordPress
+Plugin Name: BackUpWordPress Backup Plugin
 Plugin URI: http://bwp.hmn.md/
 Description: Simple automated backups of your WordPress powered website. Once activated you'll find me under <strong>Tools &rarr; Backups</strong>. On multisite, you'll find me under the Network Settings menu.
 Version: 3.2.0


### PR DESCRIPTION
Plugins are ranked by exact search term match. So if you search for backup or backups, the first results will be plugins with "backup or "backups" as a word in them
Not sure if we need to rebrand or just change the name:

Not sure if we can use `BackUp WordPress`, so maybe  `BackUpWordPress Backup Plugin`, other plugin authors are already using the trick.

@willmot @noeltock @owaincuvelier thoughts?