### PR TITLE
Fixes the zip method backup

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -1480,7 +1480,6 @@ namespace HM\BackUpWordPress {
 					$rule = '^' . $rule;
 				}
 
-
 			}
 
 			// Escape shell args for zip command

--- a/tests/other/testBackupPath.php
+++ b/tests/other/testBackupPath.php
@@ -166,7 +166,6 @@ class testBackupPathTestCase extends HM_Backup_UnitTestCase {
 			$this->assertFileExists( $this->path->get_path() . '/' . $backup );
 		}
 
-
 	}
 
 	/**


### PR DESCRIPTION
The `user_can_connect` method was wrongly coded. It established a connection but then didn't quit so it made it impossible to execute any other commands.
This PR fixes that by adding the `--execute` option with a value of `quit` to quit the mysql command prompt immediately.

Also it makes the `FS` option a user defined constant because it was causing too many issues.
It also adds some user defined constants for forcing the zip method. Useful for debugging.