### PR TITLE
Settings validation logic error

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -284,7 +284,7 @@ function hmbkp_edit_schedule_submit() {
 
 	}
 
-	if ( isset( $_POST['hmbkp_schedule_recurrence']['hmbkp_schedule_start_day_of_month'] ) ) {
+	if ( ( 'hmbkp_monthly' === $schedule_recurrence_type ) && isset( $_POST['hmbkp_schedule_recurrence']['hmbkp_schedule_start_day_of_month'] ) ) {
 
 		$day_of_month = absint( $_POST['hmbkp_schedule_recurrence']['hmbkp_schedule_start_day_of_month'] );
 


### PR DESCRIPTION
If a user selects "once monthly" and removes the value from the "day of month" field then switches to a schedule that does not use that field, and submits the form, it causes a form validation error.
we should not validate a field value if it will not be used, maybe we can do it with JS on the dropdown event, we can set a default value