### PR TITLE
Fixes full backup tests

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -3,7 +3,7 @@
 Plugin Name: BackUpWordPress Backup Plugin
 Plugin URI: http://bwp.hmn.md/
 Description: Simple automated backups of your WordPress powered website. Once activated you'll find me under <strong>Tools &rarr; Backups</strong>. On multisite, you'll find me under the Network Settings menu.
-Version: 3.2.3
+Version: 3.2.4
 Author: Human Made Limited
 Author URI: http://hmn.md/
 License: GPL-2.0+

--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -1205,11 +1205,13 @@ namespace HM\BackUpWordPress {
 		}
 
 		/**
-		 * Return an array of all files in the filesystem
+		 * Return an array of all files in the filesystem.
 		 *
-		 * @return \RecursiveIteratorIterator
+		 * @param bool $ignore_default_exclude_rules If true then will return all files under root. Otherwise returns all files except those matching default exclude rules.
+		 *
+		 * @return array
 		 */
-		public function get_files() {
+		public function get_files( $ignore_default_exclude_rules = false ) {
 
 			$found = array();
 
@@ -1222,8 +1224,11 @@ namespace HM\BackUpWordPress {
 			$finder->ignoreDotFiles( false );
 			$finder->ignoreUnreadableDirs();
 
-			foreach ( $this->default_excludes() as $exclude ) {
-				$finder->notPath( $exclude );
+			if ( ! $ignore_default_exclude_rules ) {
+				// Skips folders/files that match default exclude patterns
+				foreach ( $this->default_excludes() as $exclude ) {
+					$finder->notPath( $exclude );
+				}
 			}
 
 			foreach ( $finder->in( $this->get_root() ) as $entry ) {
@@ -1249,7 +1254,7 @@ namespace HM\BackUpWordPress {
 
 			$excludes = $this->exclude_string( 'regex' );
 
-			foreach ( $this->get_files() as $file ) {
+			foreach ( $this->get_files( true ) as $file ) {
 
 				// Skip dot files, they should only exist on versions of PHP between 5.2.11 -> 5.3
 				if ( method_exists( $file, 'isDot' ) && $file->isDot() ) {
@@ -1289,7 +1294,7 @@ namespace HM\BackUpWordPress {
 
 			$excludes = $this->exclude_string( 'regex' );
 
-			foreach ( $this->get_files() as $file ) {
+			foreach ( $this->get_files( true ) as $file ) {
 
 				// Skip dot files, they should only exist on versions of PHP between 5.2.11 -> 5.3
 				if ( method_exists( $file, 'isDot' ) && $file->isDot() ) {
@@ -1325,7 +1330,7 @@ namespace HM\BackUpWordPress {
 
 			$this->unreadable_files = array();
 
-			foreach ( $this->get_files() as $file ) {
+			foreach ( $this->get_files( true ) as $file ) {
 
 				// Skip dot files, they should only exist on versions of PHP between 5.2.11 -> 5.3
 				if ( method_exists( $file, 'isDot' ) && $file->isDot() ) {

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -11,7 +11,7 @@ register_deactivation_hook( __FILE__, array( 'HM\BackUpWordPress\Setup', 'deacti
  * Class Plugin
  */
 final class Plugin {
-	const PLUGIN_VERSION = '3.2.3';
+	const PLUGIN_VERSION = '3.2.4';
 
 	/**
 	 * @var Plugin The singleton instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BackUpWordPress",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Simple automated backups of your WordPress powered website.",
   "main": "backupwordpress.php",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: humanmade, willmot, pauldewouters, joehoyle, mattheu, tcrsavage, c
 Tags: back up, backup, backups, database, zip, db, files, archive, wp-cli, humanmade
 Requires at least: 3.9
 Tested up to: 4.2-beta
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 
 Simple automated backups of your WordPress powered website.
 
@@ -139,6 +139,16 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
   * This is a critical update. Fixes a bug in the core backup library. Please update immediately.
 
 == Changelog ==
+
+### 3.2.4 / 2015-04-01
+
+* Fixes default exclude pattern that was too greedy.
+
+### 3.2.3 / 2015-04-01
+
+* Fixes issue where files where 'cache' files were excluded by default.
+* Updates brazilian portuguese translations.
+* Fixes the issue with the 'no thanks' button in the Support modal and misc JS improvements. props SiamKreative.
 
 ### 3.2.2 / 2015-03-25
 

--- a/readme/readme-footer.txt
+++ b/readme/readme-footer.txt
@@ -36,6 +36,10 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
 
 == Changelog ==
 
+### 3.2.4 / 2015-04-01
+
+* Fixes default exclude pattern that was too greedy.
+
 ### 3.2.3 / 2015-04-01
 
 * Fixes issue where files where 'cache' files were excluded by default.

--- a/readme/readme-header.txt
+++ b/readme/readme-header.txt
@@ -3,7 +3,7 @@ Contributors: humanmade, willmot, pauldewouters, joehoyle, mattheu, tcrsavage, c
 Tags: back up, backup, backups, database, zip, db, files, archive, wp-cli, humanmade
 Requires at least: 3.9
 Tested up to: 4.2-beta
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 
 Simple automated backups of your WordPress powered website.
 

--- a/tests/backup/testFullBackupTest.php
+++ b/tests/backup/testFullBackupTest.php
@@ -25,7 +25,6 @@ class testFullBackUpTestCase extends HM_Backup_UnitTestCase {
 	public function setUp() {
 
 		$this->backup = new HM\BackUpWordPress\Backup();
-		$this->backup->set_excludes( '.git/' );
 
 		if ( defined( 'HMBKP_PATH' ) ) {
 			$this->markTestSkipped( 'Skipped because of defines' );


### PR DESCRIPTION
When I refactored the plugin in 3.2.0 , I made it so `get_files` would just skip default excludes completely. However, `get_files` is used in `get_included_files` which is used by the full backup unit tests functions to test if the resulting zip archive contains the same number of folders and files as there actually should be.
As the full backup tests don't run anymore on Travis - they are completely excluded, I didn't notice that some default exclude patterns were too greedy. This led to some core files being excluded. Including some BackUpWordPress files ( `backups.php` and `backup-table.php` )

Should we revert to running full backup tests on Travis?