### PR TITLE
Get home path should return defined value

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -255,6 +255,10 @@ namespace HM\BackUpWordPress {
 		 */
 		public static function get_home_path() {
 
+			if ( defined( 'HMBKP_ROOT' ) && HMBKP_ROOT ) {
+				return self::conform_dir( HMBKP_ROOT );
+			}
+
 			$home_url = home_url();
 			$site_url = site_url();
 
@@ -311,10 +315,6 @@ namespace HM\BackUpWordPress {
 			set_error_handler( array( $this, 'error_handler' ) );
 
 			// Some properties can be overridden with defines
-			if ( defined( 'HMBKP_ROOT' ) && HMBKP_ROOT ) {
-				$this->set_root( HMBKP_ROOT );
-			}
-
 			if ( defined( 'HMBKP_EXCLUDE' ) && HMBKP_EXCLUDE ) {
 				$this->set_excludes( HMBKP_EXCLUDE, true );
 			}


### PR DESCRIPTION
I'm trying to run this on a multisite with WP in a subdirectory. This is only possible if I can define the HMBKP_ROOT - as this is incorrectly calculated otherwise.

However `get_home_path` doesn't use the defined value. If this is added here - it all works fine.
