### PR TITLE
Exclude backups folder from size calculation

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -173,6 +173,7 @@ namespace HM\BackUpWordPress {
 			'backup-db',
 			'Envato-backups',
 			'managewp',
+			'backupwordpress-*-backups'
 		);
 
 		/**


### PR DESCRIPTION
I had wrongly removed an exclude pattern causing the total size to be miscalculated