### PR TITLE
[WIP] Deactivates the plugin if it has been activated

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -50,5 +50,11 @@ if ( version_compare( phpversion(), '5.3', '>=' ) ) {
 	require_once( HMBKP_PLUGIN_PATH . 'classes/class-plugin.php' );
 
 } else {
+
+	if ( ! function_exists( 'deactivate_plugins' ) ) {
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+	}
+	
+	deactivate_plugins( plugin_basename( __FILE__ ) );
 	wp_die( sprintf( __( 'BackUpWordPress will not work on this site. ( PHP Version %s is unsupported )', 'backupwordpress' ), phpversion() ), __( 'BackUpWordPress Error', 'backupwordpress' ), array( 'back_link' => true ) );
 }


### PR DESCRIPTION
Users have been reporting that after upgrading, their admin has been inaccessible due to the PHP version check.
However I have tried to reproduce locally by installing and activating version 3.0 on a PHP 5.2 install and then upgrading to the latest version and the plugin deactivates itself. So I'm not able to reproduce.