### PR TITLE
Error if variable is wrong type

### DIFF
--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -505,7 +505,7 @@ class Scheduled_Backup {
 
 		// Skip missing or unreadable files
 		if ( ! file_exists( $file->getPathname() ) || ! $file->getRealpath() || ! $file->isReadable() ) {
-			return false;
+			return 0;
 		}
 
 		// If it's a file then just pass back the filesize
@@ -532,7 +532,7 @@ class Scheduled_Backup {
 
 				}
 
-				return;
+				return 0;
 
 			}
 


### PR DESCRIPTION
`Warning: array_key_exists() [function.array-key-exists]: The first argument should be either a string or an integer in /home/content/52/9722152/html/wp-content/plugins/backupwordpress/classes/class-schedule.php on line 416`