### PR TITLE
Fixes admin page slug for multisite

### DIFF
--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -19,7 +19,7 @@ hmbkp_clear_settings_errors();
 
 ?>
 
-<form method="post" action="<?php echo esc_url( self_admin_url( 'admin-post.php' ) ); ?>">
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 
 	<input type="hidden" name="hmbkp_schedule_id" value="<?php echo esc_attr( $schedule->get_id() ); ?>" />
 	<input type="hidden" name="action" value="hmbkp_edit_schedule_submit" />

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -101,8 +101,8 @@ final class Plugin {
 
 		if ( ! defined( 'HMBKP_ADMIN_PAGE' ) ) {
 			$prefix = is_multisite() ? 'settings_page_' : 'tools_page_';
-			$suffix = is_multisite() ? '-network' : '';
-			define( 'HMBKP_ADMIN_PAGE', $prefix . HMBKP_PLUGIN_SLUG . $suffix );
+
+			define( 'HMBKP_ADMIN_PAGE', $prefix . HMBKP_PLUGIN_SLUG );
 		}
 
 		define( 'HMBKP_SECURE_KEY', $this->generate_key() );

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -67,7 +67,7 @@ final class Plugin {
 
 			add_action( 'admin_init', array( 'HM\BackUpWordPress\Setup', 'self_deactivate' ) );
 
-			add_action( 'admin_notices', array( 'HM\BackUpWordPress\Setup', 'display_admin_notices' ) );
+			add_action( 'all_admin_notices', array( 'HM\BackUpWordPress\Setup', 'display_admin_notices' ) );
 
 			return true;
 
@@ -101,7 +101,8 @@ final class Plugin {
 
 		if ( ! defined( 'HMBKP_ADMIN_PAGE' ) ) {
 			$prefix = is_multisite() ? 'settings_page_' : 'tools_page_';
-			define( 'HMBKP_ADMIN_PAGE', $prefix . HMBKP_PLUGIN_SLUG );
+			$suffix = is_multisite() ? '-network' : '';
+			define( 'HMBKP_ADMIN_PAGE', $prefix . HMBKP_PLUGIN_SLUG . $suffix );
 		}
 
 		define( 'HMBKP_SECURE_KEY', $this->generate_key() );

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -357,7 +357,7 @@ function hmbkp_translated_schedule_title( $slug, $title ) {
 
 function hmbkp_get_settings_url() {
 
-	$url = is_multisite() ? self_admin_url( 'settings.php?page=' . HMBKP_PLUGIN_SLUG ) : self_admin_url( 'tools.php?page=' . HMBKP_PLUGIN_SLUG );
+	$url = is_multisite() ? network_admin_url( 'settings.php?page=' . HMBKP_PLUGIN_SLUG ) : admin_url( 'tools.php?page=' . HMBKP_PLUGIN_SLUG );
 
 	HM\BackUpWordPress\schedules::get_instance()->refresh_schedules();
 


### PR DESCRIPTION
I'm not sure why, but the multisite `get_current_screen` returns `settings_backupwordpress-network` not `settings_backupwordpress`