### PR TITLE
Site size isn't ignoring excluded files

### DIFF
--- a/admin/schedule-sentence.php
+++ b/admin/schedule-sentence.php
@@ -155,7 +155,7 @@ function hmbkp_get_site_size_text( HM\BackUpWordPress\Scheduled_Backup $schedule
 
 	} elseif ( ( 'database' === $schedule->get_type() ) || $schedule->is_site_size_cached() ) {
 
-		return sprintf( '(<code title="' . __( 'Backups will be compressed and should be smaller than this.', 'backupwordpress' ) . '">%s</code>)', esc_attr( $schedule->get_formatted_site_size() ) );
+		return sprintf( '(<code title="' . __( 'Backups will be compressed and should be smaller than this.', 'backupwordpress' ) . '">%s</code>)', esc_attr( $schedule->get_formatted_site_size( true ) ) );
 
 	} else {
 

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -311,7 +311,7 @@ class Scheduled_Backup {
 	 *
 	 * @return string
 	 */
-	public function get_site_size() {
+	public function get_site_size( $skip_excluded_files = false ) {
 
 		$size = 0;
 
@@ -332,7 +332,7 @@ class Scheduled_Backup {
 
 			$root = new \SplFileInfo( $this->backup->get_root() );
 
-			$size += $this->filesize( $root );
+			$size += $this->filesize( $root, $skip_excluded_files );
 
 		}
 
@@ -347,8 +347,8 @@ class Scheduled_Backup {
 	 *
 	 * @return bool|string
 	 */
-	public function get_formatted_site_size() {
-		return size_format( $this->get_site_size() );
+	public function get_formatted_site_size( $skip_excluded_files = false ) {
+		return size_format( $this->get_site_size( $skip_excluded_files ) );
 	}
 
 	/**


### PR DESCRIPTION
And it should be, this was broken at some point. I think in https://github.com/humanmade/backupwordpress/pull/743

I found two issues.

- We were no longer passing the `$skip_excluded_files` argument all the way through to `filesize`. Fixed that in https://github.com/humanmade/backupwordpress/commit/16d0ddfb8485e2a3dc0a59bc6d34f172078bb526
- https://github.com/humanmade/backupwordpress/commit/d8ba9e4f15ccfdc480b03ee51cc2fbf16966a6e8 shortcuts filesize so it doesn't ever get to the exclude ignoring code if it's passed the route directoy. @pdewouters any idea why that was added?