### PR TITLE
Ensure we create the `.htaccess` file instead of relying on `insert_with_markers` to create it

### DIFF
--- a/classes/class-path.php
+++ b/classes/class-path.php
@@ -255,6 +255,8 @@ class Path {
 			$contents[] = '</IfModule>';
 			$contents[] = '';
 
+			file_put_contents( $htaccess, '' );
+
 			insert_with_markers( $htaccess, 'BackUpWordPress', $contents );
 
 		}


### PR DESCRIPTION
Fixes the unit test errors reported in https://github.com/humanmade/backupwordpress/pull/869#issuecomment-144707430

See https://core.trac.wordpress.org/ticket/31767 for discussion on the Core change we caused this to be an issue.