### PR TITLE
Fix false positive error message

### DIFF
--- a/classes/class-backup.php
+++ b/classes/class-backup.php
@@ -933,14 +933,15 @@ class Backup {
 			// Is zip available
 			if ( $this->get_zip_command_path() ) {
 				$this->zip();
+			} else {
+				// If the shell zip failed then use ZipArchive
+				if ( empty( $this->archive_verified ) && class_exists( 'ZipArchive' ) ) {
+					$this->zip_archive();
+				} else {
+					$this->warning( $this->get_archive_method(), __( 'No valid archive method found.', 'backupwordpress' ) );
+				}
 			}
 
-			// If the shell zip failed then use ZipArchive
-			if ( ! $this->get_zip_command_path() || empty( $this->archive_verified ) && class_exists( 'ZipArchive' ) ) {
-				$this->zip_archive();
-			} else {
-				$this->warning( $this->get_archive_method(), __( 'No valid archive method found.', 'backupwordpress' ) );
-			}
 		}
 
 		// Delete the database dump file


### PR DESCRIPTION
When the `zip` method was used, it would then evaluate the next conditional and always evaluate the condition that displays the `no valid archive method found`
