### PR TITLE
Beginning of catching fatal errors and timeouts

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -78,7 +78,13 @@ function hmbkp_request_do_backup() {
 	session_write_close();
 
 	$schedule_id = sanitize_text_field( urldecode( $_POST['hmbkp_schedule_id'] ) );
-	$task = new \HM\Backdrop\Task( 'hmbkp_run_schedule_async', $schedule_id );
+
+	$schedule = new HM\BackUpWordPress\Scheduled_Backup( $schedule_id );
+
+	$task = new \HM\Backdrop\Task( 'hmbkp_run_schedule_async', $schedule );
+
+	\HM\BackUpWordPress\Task_Manager::get_instance()->add_task( $schedule_id, $task );
+
 	$task->schedule();
 
 	die;
@@ -86,9 +92,7 @@ function hmbkp_request_do_backup() {
 }
 add_action( 'wp_ajax_hmbkp_run_schedule', 'hmbkp_request_do_backup' );
 
-function hmbkp_run_schedule_async( $schedule_id ) {
-
-	$schedule = new HM\BackUpWordPress\Scheduled_Backup( $schedule_id );
+function hmbkp_run_schedule_async( $schedule ) {
 
 	$schedule->run();
 

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -117,6 +117,7 @@ final class Plugin {
 		require_once( HMBKP_PLUGIN_PATH . 'vendor/autoload.php' );
 
 		require_once( HMBKP_PLUGIN_PATH . 'classes/class-notices.php' );
+		require_once( HMBKP_PLUGIN_PATH . 'classes/class-task-manager.php' );
 
 		// Load the admin menu
 		require_once( HMBKP_PLUGIN_PATH . 'admin/menu.php' );

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -124,6 +124,8 @@ class Scheduled_Backup {
 
 			$task->cancel();
 
+			$task = \HM\BackUpWordPress\Task_Manager::get_instance()->remove_task( $this->get_id() );
+
 		}
 	}
 

--- a/classes/class-task-manager.php
+++ b/classes/class-task-manager.php
@@ -1,0 +1,71 @@
+<?php
+namespace HM\BackUpWordPress;
+
+class Task_Manager {
+
+	/**
+	 * Holds an instance of the class.
+	 *
+	 * @var Task_Manager
+	 */
+	private static $_instance;
+
+	/**
+	 * Array of Backdrop tasks.
+	 *
+	 * @var
+	 */
+	protected $tasks = array();
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+
+		$this->tasks = get_site_option( 'hmbkp_tasks', array() );
+	}
+
+	/**
+	 * Returns the singleton instance of this class.
+	 * @return Task_Manager
+	 */
+	public static function get_instance() {
+
+		if ( ! ( self::$_instance instanceof Task_Manager ) ) {
+			self::$_instance = new Task_Manager();
+		}
+
+		return self::$_instance;
+
+	}
+
+	/**
+	 * Returns a Backdrop task corresponding to the schedule ID.
+	 * @param $schedule_id
+	 *
+	 * @return mixed
+	 */
+	public function get_task( $schedule_id ) {
+
+		return $this->tasks[ $schedule_id ];
+	}
+
+	/**
+	 * Adds a Task to the list, indexed by schedule ID.
+	 * @param                   $schedule_id
+	 * @param \HM_Backdrop_Task $task
+	 */
+	public function add_task( $schedule_id, \HM_Backdrop_Task $task ) {
+		$this->tasks[ $schedule_id ] = $task;
+		update_site_option( 'hmbkp_tasks', $this->tasks );
+	}
+
+	/**
+	 * Deletes a task.
+	 * @param $schedule_id
+	 */
+	public function remove_task( $schedule_id ) {
+		unset( $this->tasks[ $schedule_id ] );
+		update_site_option( 'hmbkp_tasks', $this->tasks );
+	}
+}

--- a/classes/class-task-manager.php
+++ b/classes/class-task-manager.php
@@ -47,6 +47,10 @@ class Task_Manager {
 	 */
 	public function get_task( $schedule_id ) {
 
+		if ( empty( $this->tasks[ $schedule_id ] ) ) {
+			return new \WP_Error( 'invalid_task' );
+		}
+
 		return $this->tasks[ $schedule_id ];
 	}
 


### PR DESCRIPTION
### Report fatal errors and fail gracefully.

- Manual jobs
  - [ ] need to reload the admin and show the cross icon
  - [ ] **time outs:** JS polling for manually started jobs. remove heartbeat 
- Scheduled ( cron ) jobs

Introduce a task manager singleton class which manages an array of Backdrop tasks ( created by running a schedule ). We need this to delete the backdrop task on error.

- [ ] amend unit tests
- [ ] handle cases where 1 schedule has multiple tasks. ( duplicate key )

### Timeouts

For manual jobs, we need to do some JS polling of the backup process to notify browser. 
For cron jobs, we need to send an email on failure.

In both cases, we can use the status file `.backuprunning` to check last status start time. If > 30min then we can decide it has failed. 
Or do we want to make it more responsive?, we'd have to continuously be writing/reading a status for that.


