### PR TITLE
Fix an issue that caused the site size to report as twice as large as it should

### DIFF
--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -34,7 +34,6 @@
 
 					<td>
 						<code><?php echo esc_html( str_ireplace( $schedule->backup->get_root(), '', $exclude ) ); ?></code>
-
 					</td>
 
 					<td>

--- a/classes/class-schedule.php
+++ b/classes/class-schedule.php
@@ -468,6 +468,7 @@ class Scheduled_Backup {
 
 		}
 
+		// If we don't have it cached then we'll need to re-calculate
 		$files = $this->backup->get_files();
 
 		foreach ( $files as $file ) {
@@ -479,9 +480,6 @@ class Scheduled_Backup {
 			}
 
 		}
-
-		// This will be the total size of the included folders MINUS default excludes.
-		$directory_sizes[ $this->backup->get_root() ] = array_sum( $directory_sizes );
 
 		set_transient( 'hmbkp_directory_filesizes', $directory_sizes, DAY_IN_SECONDS );
 
@@ -535,10 +533,6 @@ class Scheduled_Backup {
 
 				return 0;
 
-			}
-
-			if ( $this->backup->get_root() === $file->getPathname() ) {
-				return $directory_sizes[ $file->getPathname() ];
 			}
 
 			$current_pathname = trailingslashit( $file->getPathname() );


### PR DESCRIPTION
Don't special case pre-calculate the root size during the directory scanner, instead rely on the directory `array_sum` like any other path.

Fixes #930 