### PR TITLE
Add release script (WIP)

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -46,19 +46,27 @@ cd "$TMPDIR"
 sed -e "s/{{TAG}}/$VERSION/g" < "$PLUGINDIR/bin/readme.txt" > readme.txt
 
 # Remove special files
-rm ".gitignore"
-rm ".scrutinizer.yml"
-rm ".travis.yml"
-rm "composer.json"
-rm "Gruntfile.js"
-rm "package.json"
-rm "phpcs.ruleset.xml"
-rm "phpunit.xml.dist"
-rm "multisite.xml"
-rm "codecoverage.xml"
-rm -r "assets"
-rm -r "bin"
-rm -r "tests"
+rm .gitignore
+rm .gitmodules
+rm .bowerrc
+rm .travis.yml
+rm .jshintrc
+rm CONTRIBUTING.md
+rm changelog.txt
+rm .scrutinizer.yml
+rm phpunit.xml
+rm bower.json
+rm Gruntfile.js
+rm package.json
+rm README.md
+rm -r bin
+rm -r grunt
+rm -r releases
+rm -r vendor/symfony/finder/Symfony/Component/Finder/Tests
+rm -r readme
+rm -r tests
+
+
 
 # Add any new files
 svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2}' | xargs svn add

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,74 @@
+# release.sh
+#
+# Takes a tag to release, and syncs it to WordPress.org
+
+TAG=$1
+
+PLUGIN="backupwordpress"
+TMPDIR=/tmp/release-svn
+PLUGINDIR="$PWD"
+PLUGINSVN="https://plugins.svn.wordpress.org/$PLUGIN"
+
+# Fail on any error
+set -e
+
+# Is the tag valid?
+if [ -z "$TAG" ] || ! git rev-parse "$TAG" > /dev/null; then
+	echo "Invalid tag. Make sure you tag before trying to release."
+	exit 1
+fi
+
+if [[ $VERSION == "v*" ]]; then
+	# Starts with an extra "v", strip for the version
+	VERSION=${TAG:1}
+else
+	VERSION="$TAG"
+fi
+
+if [ -d "$TMPDIR" ]; then
+	# Wipe it clean
+	rm -r "$TMPDIR"
+fi
+
+# Ensure the directory exists first
+mkdir "$TMPDIR"
+
+# Grab an unadulterated copy of SVN
+svn co "$PLUGINSVN/trunk" "$TMPDIR" > /dev/null
+
+# Extract files from the Git tag to there
+git archive --format="zip" -0 "$TAG" | tar -C "$TMPDIR" -xf -
+
+# Switch to build dir
+cd "$TMPDIR"
+
+# Run build tasks
+sed -e "s/{{TAG}}/$VERSION/g" < "$PLUGINDIR/bin/readme.txt" > readme.txt
+
+# Remove special files
+rm ".gitignore"
+rm ".scrutinizer.yml"
+rm ".travis.yml"
+rm "composer.json"
+rm "Gruntfile.js"
+rm "package.json"
+rm "phpcs.ruleset.xml"
+rm "phpunit.xml.dist"
+rm "multisite.xml"
+rm "codecoverage.xml"
+rm -r "assets"
+rm -r "bin"
+rm -r "tests"
+
+# Add any new files
+svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2}' | xargs svn add
+
+# Pause to allow checking
+echo "About to commit $VERSION. Double-check $TMPDIR to make sure everything looks fine."
+read -p "Hit Enter to continue."
+
+# Commit the changes
+svn commit -m "Tag $VERSION"
+
+# tag_ur_it
+svn copy "$PLUGINSVN/trunk" "$PLUGINSVN/tags/$VERSION" -m "Tag $VERSION"

--- a/grunt/concat.js
+++ b/grunt/concat.js
@@ -5,6 +5,6 @@ module.exports = {
 			'readme/faq.txt',
 			'readme/readme-footer.txt'
 		],
-		dest: 'readme.txt'
+		dest: 'bin/readme.txt'
 	}
 };


### PR DESCRIPTION
This script is adapted from the WP API repo.
Once a new version has been tagged and released on github, running `./release.sh {tag}` will download a copy and sync with svn.
It also takes care of deleting unneeded build files before uploading to wp.org

first run `svn list http://plugins.wordpress.org` to accept the certificate

then run `bin/./release.sh {tag}` from the plugin root folder

This will render the `grunt release` step unnecessary, as well as creating the tag release manually.

