### PR TITLE
3 3 4 release

### DIFF
--- a/backupwordpress.php
+++ b/backupwordpress.php
@@ -3,7 +3,7 @@
 Plugin Name: BackUpWordPress
 Plugin URI: http://bwp.hmn.md/
 Description: Simple automated backups of your WordPress powered website. Once activated you'll find me under <strong>Tools &rarr; Backups</strong>. On multisite, you'll find me under the Network Settings menu.
-Version: 3.3.3
+Version: 3.3.4
 Author: Human Made Limited
 Author URI: http://hmn.md/
 License: GPL-2+

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -6,7 +6,7 @@ namespace HM\BackUpWordPress;
  * Class Plugin
  */
 final class Plugin {
-	const PLUGIN_VERSION = '3.3.3';
+	const PLUGIN_VERSION = '3.3.4';
 
 	/**
 	 * @var Plugin The singleton instance.

--- a/grunt/aliases.yml
+++ b/grunt/aliases.yml
@@ -7,12 +7,12 @@ build-dev:
   - compress:dev
 
 build:
-  - makepot
   - autoprefixer
   - cssmin
   - uglify
   - bumpup # defaults to patch, change to :minor or :major if necessary
   - replace # Update version numbers, build faq.txt
+  - makepot
 
 # before running release, make sure to add the changelog to readme-footer.txt Also, update the "tested up to" version if necessary
 release:

--- a/languages/backupwordpress.pot
+++ b/languages/backupwordpress.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL-2+.
 msgid ""
 msgstr ""
-"Project-Id-Version: BackUpWordPress 3.3.2\n"
+"Project-Id-Version: BackUpWordPress 3.3.4\n"
 "Report-Msgid-Bugs-To: backupwordpress@hmn.md\n"
-"POT-Creation-Date: 2015-11-13 13:55:19+00:00\n"
+"POT-Creation-Date: 2015-12-10 13:34:05+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Human Made Limited\n"
 "Language-Team: Human Made Limited\n"
-"X-Generator: grunt-wp-i18n 0.5.3\n"
+"X-Generator: grunt-wp-i18n 0.4.9\n"
 
 #: admin/actions.php:191
 msgid "The schedule ID was not provided. Aborting."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BackUpWordPress",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Simple automated backups of your WordPress powered website.",
   "main": "backupwordpress.php",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: humanmade, willmot, pauldewouters, joehoyle, mattheu, tcrsavage, c
 Tags: back up, backup, backups, database, zip, db, files, archive, wp-cli, humanmade
 Requires at least: 3.9
 Tested up to: 4.4
-Stable tag: 3.3.3
+Stable tag: 3.3.4
 
 Simple automated backups of your WordPress-powered website.
 
@@ -118,6 +118,10 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
 
 == Upgrade Notice ==
 
+= 3.3.4 =
+
+* WordPress 4.4 compatibility.
+
 = 3.3.1 =
 
 * Fixes a bug that would prevent downloading backups since 3.3.0 - please update.
@@ -147,6 +151,10 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
   * This is a critical update. Fixes a bug in the core backup library. Please update immediately.
 
 == Changelog ==
+
+### 3.3.4 / 2015-12-10
+
+* Fixes styling issues with WordPress 4.4
 
 ### 3.3.3 / 2015-11-13
 

--- a/readme.txt
+++ b/readme.txt
@@ -136,19 +136,19 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
 
 = 3.1.3 =
 
-  * Fixes backwards compatibility for add-ons and avoids a Fatal Error. Please upgrade straight to this version before upgrading your add-ons.
-  
+* Fixes backwards compatibility for add-ons and avoids a Fatal Error. Please upgrade straight to this version before upgrading your add-ons.
+
 = 3.0.4 =
 
-  * Fixes a few minor bugs. Immediate update is recommended.
+* Fixes a few minor bugs. Immediate update is recommended.
 
 = 3.0.2 =
 
-  * Important: we have dropped support for PHP 5.2, you will not be able to activate BackUpWordPress on a server running PHP versions older than PHP 5.3.29
+* Important: we have dropped support for PHP 5.2, you will not be able to activate BackUpWordPress on a server running PHP versions older than PHP 5.3.29
 
 = 3.0.1 =
 
-  * This is a critical update. Fixes a bug in the core backup library. Please update immediately.
+* This is a critical update. Fixes a bug in the core backup library. Please update immediately.
 
 == Changelog ==
 

--- a/readme/readme-footer.txt
+++ b/readme/readme-footer.txt
@@ -14,6 +14,10 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
 
 == Upgrade Notice ==
 
+= 3.3.4 =
+
+* WordPress 4.4 compatibility.
+
 = 3.3.1 =
 
 * Fixes a bug that would prevent downloading backups since 3.3.0 - please update.
@@ -43,6 +47,10 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
   * This is a critical update. Fixes a bug in the core backup library. Please update immediately.
 
 == Changelog ==
+
+### 3.3.4 / 2015-12-10
+
+* Fixes styling issues with WordPress 4.4
 
 ### 3.3.3 / 2015-11-13
 

--- a/readme/readme-footer.txt
+++ b/readme/readme-footer.txt
@@ -32,19 +32,19 @@ You can also tweet <a href="http://twitter.com/humanmadeltd">@humanmadeltd</a> o
 
 = 3.1.3 =
 
-  * Fixes backwards compatibility for add-ons and avoids a Fatal Error. Please upgrade straight to this version before upgrading your add-ons.
-  
+* Fixes backwards compatibility for add-ons and avoids a Fatal Error. Please upgrade straight to this version before upgrading your add-ons.
+
 = 3.0.4 =
 
-  * Fixes a few minor bugs. Immediate update is recommended.
+* Fixes a few minor bugs. Immediate update is recommended.
 
 = 3.0.2 =
 
-  * Important: we have dropped support for PHP 5.2, you will not be able to activate BackUpWordPress on a server running PHP versions older than PHP 5.3.29
+* Important: we have dropped support for PHP 5.2, you will not be able to activate BackUpWordPress on a server running PHP versions older than PHP 5.3.29
 
 = 3.0.1 =
 
-  * This is a critical update. Fixes a bug in the core backup library. Please update immediately.
+* This is a critical update. Fixes a bug in the core backup library. Please update immediately.
 
 == Changelog ==
 

--- a/readme/readme-header.txt
+++ b/readme/readme-header.txt
@@ -3,7 +3,7 @@ Contributors: humanmade, willmot, pauldewouters, joehoyle, mattheu, tcrsavage, c
 Tags: back up, backup, backups, database, zip, db, files, archive, wp-cli, humanmade
 Requires at least: 3.9
 Tested up to: 4.4
-Stable tag: 3.3.3
+Stable tag: 3.3.4
 
 Simple automated backups of your WordPress-powered website.
 


### PR DESCRIPTION
Bump our version numbers ready for release.

Adds the changelog and an update notice noting WordPress 4.4 compatibility.

Also fixes a minor issue with the build command where the version number in the `.pot` file would be the old version.