### PR TITLE
Stop using shell_exec in warning messages.

### DIFF
--- a/classes/class-requirement.php
+++ b/classes/class-requirement.php
@@ -317,12 +317,12 @@ Requirements::register( 'HM\BackUpWordPress\Requirement_Safe_Mode', 'PHP' );
 /**
  * Class Requirement_Shell_Exec
  */
-class Requirement_Shell_Exec extends Requirement {
+class Requirement_Exec extends Requirement {
 
 	/**
 	 * @var string
 	 */
-	var $name = 'Shell Exec';
+	var $name = 'Exec';
 
 	/**
 	 * @return bool
@@ -332,7 +332,7 @@ class Requirement_Shell_Exec extends Requirement {
 	}
 
 }
-Requirements::register( 'HM\BackUpWordPress\Requirement_Shell_Exec', 'PHP' );
+Requirements::register( 'HM\BackUpWordPress\Requirement_Exec', 'PHP' );
 
 /**
  * Class Requirement_Memory_Limit

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -149,21 +149,12 @@ function set_server_config_notices() {
 
 	$messages = array();
 
-	if ( ! Backup_Utilities::is_exec_available() ) {
-		$php_user  = '<PHP USER>';
-		$php_group = '<PHP GROUP>';
-	} else {
-		$php_user  = shell_exec( 'whoami' );
-		$groups = explode( ' ', shell_exec( 'groups' ) );
-		$php_group = reset( $groups );
-	}
-
 	if ( ! is_dir( Path::get_path() ) ) {
-		$messages[] = sprintf( __( 'The backups directory can\'t be created because your %1$s directory isn\'t writable. Run %2$s or %3$s or create the folder yourself.', 'backupwordpress' ), '<code>' . esc_html( dirname( Path::get_path() ) ) . '</code>', '<code>chown ' . esc_html( $php_user ) . ':' . esc_html( $php_group ) . ' ' . esc_html( dirname( Path::get_path() ) ) . '</code>', '<code>chmod 777 ' . esc_html( dirname( Path::get_path() ) ) . '</code>' );
+		$messages[] = sprintf( __( 'The backups directory can\'t be created because your %s directory isn\'t writable. Please create the folder manually.', 'backupwordpress' ), '<code>' . esc_html( dirname( Path::get_path() ) ) . '</code>' );
 	}
 
 	if ( is_dir( Path::get_path() ) && ! wp_is_writable( Path::get_path() ) ) {
-		$messages[] = sprintf( __( 'Your backups directory isn\'t writable. Run %1$s or %2$s or set the permissions yourself.', 'backupwordpress' ), '<code>chown -R ' . esc_html( $php_user ) . ':' . esc_html( $php_group ) . ' ' . esc_html( Path::get_path() ) . '</code>', '<code>chmod -R 777 ' . esc_html( Path::get_path() ) . '</code>' );
+		$messages[] = __( 'The backups directory isn\'t writable. Please fix the permissions.', 'backupwordpress' );
 	}
 
 	if ( Backup_Utilities::is_safe_mode_on() ) {


### PR DESCRIPTION
This fixes a PHP Warning when `shell_exec` is disabled.

Instead of using `shell_exec` to find the PHP User and Group we now just show placeholders in the error message. The eventual plan will be to replace these error message with something better (see https://github.com/humanmade/backupwordpress/pull/833)

Also corrects the name of `Exec` requirements check, it was incorrectly mentioning Shell Exec.

Fixes https://github.com/humanmade/backupwordpress/issues/965