### PR TITLE
Ensure our subdirectory check doesn't also match wordpres installed inside wordpress

### DIFF
--- a/classes/class-path.php
+++ b/classes/class-path.php
@@ -105,18 +105,15 @@ class Path {
 
 		if ( path_in_php_open_basedir( dirname( $site_path ) ) ) {
 
-			// Handle wordpress installed in a subdirectory
-			// 1. index.php and wp-config.php found in parent dir
-			// 2. index.php in parent dir, wp-config.php in $site_path ( wp-config.php can be in both locations )
-			if ( ( file_exists( dirname( $site_path ) . '/wp-config.php' ) || file_exists( $site_path . '/wp-config.php' ) )  && file_exists( dirname( $site_path ) . '/index.php' ) ) {
+			/**
+			 * Standard subdirectory install
+			 *
+			 * index.php in parent directory and not in root
+			 * wp-config either in root or parent
+			 */
+			if ( file_exists( dirname( $site_path ) . '/index.php' ) && ! file_exists( $site_path . '/index.php' ) && ( file_exists( dirname( $site_path ) . '/wp-config.php' ) || file_exists( $site_path . '/wp-config.php' ) ) ) {
 				$home_path = dirname( $site_path );
 			}
-
-			// Handle wp-config.php being above site_path
-			if ( file_exists( dirname( $site_path ) . '/wp-config.php' ) && ! file_exists( $site_path . '/wp-config.php' ) && ! file_exists( dirname( $site_path ) . '/index.php' ) ) {
-				$home_path = $site_path;
-			}
-
 		}
 
 		return wp_normalize_path( untrailingslashit( $home_path ) );

--- a/tests/class-backup-utilities/test-get-home-path.php
+++ b/tests/class-backup-utilities/test-get-home-path.php
@@ -69,6 +69,18 @@ class Home_Path_Tests extends \HM_Backup_UnitTestCase {
 
 	}
 
+	function test_wordpress_inside_wordpress() {
+
+		$abspath = $this->test_data . '/exclude' ;
+		$this->wp_config_in( $abspath );
+		$this->index_in( $abspath );
+		$this->index_in( dirname( $abspath ) );
+		$path = Path::get_home_path( $abspath );
+
+		$this->assertEquals( $abspath, $path );
+
+	}
+
 	private function wp_config_in( $path ) {
 		file_put_contents( trailingslashit( $path ) . 'wp-config.php', '// I am your father' );
 	}
@@ -76,5 +88,4 @@ class Home_Path_Tests extends \HM_Backup_UnitTestCase {
 	private function index_in( $path ) {
 		file_put_contents( trailingslashit( $path ) . 'index.php', '// shhh' );
 	}
-
 }


### PR DESCRIPTION
Our subdirectory check was incorrectly matching against the following:

```
index.php // Standard install.
foo/
- index.php // Another standard install in a folder inside another install.
bar/
- index.php // A third WordPress install.

```

In the above case `foo/` & `bar/` would be incorrectly detected as a sub-directory installs, `home_path` would be set to the parent directory and each sub-site would end up backing up the entire root directory.

We resolve this by only matching sub-directory installs if there is an `index.php` in the parent and there isn't one in the current directory.

Also adds a unit test to cover this case.