### PR TITLE
Ensure temporary files are correctly cleaned up before and after running a backup

### DIFF
--- a/classes/backup/class-backup.php
+++ b/classes/backup/class-backup.php
@@ -37,6 +37,8 @@ class Backup {
 
 	public function run() {
 
+		Path::get_instance()->cleanup();
+
 		if ( $this->type !== 'file' ) {
 			$this->backup_database();
 		}
@@ -44,6 +46,8 @@ class Backup {
 		if ( $this->type !== 'database' ) {
 			$this->backup_files();
 		}
+
+		Path::get_instance()->cleanup();
 
 	}
 

--- a/classes/class-path.php
+++ b/classes/class-path.php
@@ -187,7 +187,7 @@ class Path {
 	}
 
 	public function reset_path() {
-		$this->set_path( false );
+		$this->path = $this->custom_path = '';
 	}
 
 	/**
@@ -429,7 +429,7 @@ class Path {
 			return;
 		}
 
-		foreach ( new CleanUpIterator( new \DirectoryIterator( $this->path ) ) as $file ) {
+		foreach ( new CleanUpIterator( new \DirectoryIterator( Path::get_path() ) ) as $file ) {
 
 			if ( $file->isDot() || ! $file->isReadable() || ! $file->isFile() ) {
 				continue;
@@ -438,15 +438,26 @@ class Path {
 			@unlink( $file->getPathname() );
 
 		}
-
 	}
-
 }
 
 class CleanUpIterator extends \FilterIterator {
 
-	// Don't match index.html,files with zip extension or status logfiles.
+	// Don't match index.html, files with zip extension or status logfiles.
 	public function accept() {
-		return ! preg_match( '/(index\.html|.*\.zip|.*-running)/', $this->current() );
+
+		// Don't remove existing backups
+		if ( 'zip' === $this->current()->getExtension() ) {
+			return false;
+		}
+
+		// Don't remove the index.html file
+		if ( 'index.html' === $this->current()->getBasename() ) {
+			return false;
+		}
+
+		// Don't cleanup the backup running file
+		return ! preg_match( '/(.*-running)/', $this->current() );
+
 	}
 }

--- a/tests/class-site-backup/test-class-site-backup.php
+++ b/tests/class-site-backup/test-class-site-backup.php
@@ -25,6 +25,23 @@ class Site_Backup_Tests extends \HM_Backup_UnitTestCase {
 
 	}
 
+	public function test_only_database_zipped_up() {
+
+		$this->backup->set_type( 'database' );
+		Path::get_instance()->reset_path();
+
+		file_put_contents( PATH::get_path() . '/foo.zip.SmuhtP', 'bar' );
+		file_put_contents( PATH::get_path() . '/zicBotXQ', 'baz' );
+
+		$this->backup->run();
+
+		$this->assertFileExists( $this->backup->get_backup_filepath() );
+		$this->assertArchiveContains( $this->backup->get_backup_filepath(), array( basename( $this->backup->get_database_backup_filepath() ) ) );
+		$this->assertArchiveNotContains( $this->backup->get_backup_filepath(), array( 'zicBotXQ', 'foo.zip.SmuhtP' ) );
+		$this->assertArchiveFileCount( $this->backup->get_backup_filepath(), 1 );
+
+	}
+
 	public function test_files_backup() {
 
 		$this->backup->set_type( 'files' );
@@ -33,7 +50,7 @@ class Site_Backup_Tests extends \HM_Backup_UnitTestCase {
 		$finder = new Mock_File_Backup_Engine;
 		$finder = $finder->get_files();
 
-		foreach( $finder as $file ) {
+		foreach ( $finder as $file ) {
 			$files[] = $file->getRelativePathname();
 		}
 
@@ -49,7 +66,7 @@ class Site_Backup_Tests extends \HM_Backup_UnitTestCase {
 		$finder = new Mock_File_Backup_Engine;
 		$finder = $finder->get_files();
 
-		foreach( $finder as $file ) {
+		foreach ( $finder as $file ) {
 			$files[] = $file->getRelativePathname();
 		}
 
@@ -75,5 +92,4 @@ class Site_Backup_Tests extends \HM_Backup_UnitTestCase {
 		$this->assertArchiveNotContains( $backup2, array( 'backup1.zip' ) );
 
 	}
-
 }

--- a/tests/test-backup-path.php
+++ b/tests/test-backup-path.php
@@ -46,7 +46,7 @@ class Test_Backup_Path extends \HM_Backup_UnitTestCase {
 
 		// Remove our custom path
 		rmdirtree( $this->custom_path );
-   
+
     	// Reset the path internally
 		$this->path->reset_path();
 
@@ -113,7 +113,7 @@ class Test_Backup_Path extends \HM_Backup_UnitTestCase {
 
 		$generated_paths = $this->generate_additional_paths();
         $paths = $this->path->get_existing_paths();
-        
+
         sort( $generated_paths );
         sort( $paths );
 
@@ -218,6 +218,27 @@ class Test_Backup_Path extends \HM_Backup_UnitTestCase {
 		}
 
 		return $paths;
+
+	}
+
+	public function test_cleanup() {
+
+		// Should be cleaned up
+		file_put_contents( PATH::get_path() . '/foo.zip.SmuhtP', 'bar' );
+		file_put_contents( PATH::get_path() . '/foo.sql', 'bar' );
+		file_put_contents( PATH::get_path() . '/zicBotXQ', 'baz' );
+
+		// Existing backups shouldn't be cleaned up
+		file_put_contents( PATH::get_path() . '/backup.zip', 'baz' );
+
+		Path::get_instance()->cleanup();
+
+		$this->assertFileNotExists( PATH::get_path() . '/foo.zip.SmuhtP' );
+		$this->assertFileNotExists( PATH::get_path() . '/foo.sql' );
+		$this->assertFileNotExists( PATH::get_path() . '/zicBotXQ' );
+
+		$this->assertFileExists( PATH::get_path() . '/index.html' );
+		$this->assertFileExists( PATH::get_path() . '/backup.zip' );
 
 	}
 


### PR DESCRIPTION
There were several issues contributing to this bug.

1. We weren't even running `Path::cleanup` before and after running a backup, we now are.
2. We were missing a unit test to verify that when backing up the database, no other files are included. We now have a unit test.
3. We were missing unit tests for `Path::cleanup` to ensure that all the files we'd expect to are actually cleaned up. We now have unit tests.
4. Those tests exposed the fact that `Path::cleanup` wasn't cleaning up `ZipArchive` temporary files. It now does.
5. `PATH::reset_path` wasn't correctly resetting the `Path::custom_path` meaning that `PATH::cleanup` wouldn't run in some situations. That's now fixed.

So in summary, before this commit temporary files from failed backups were not correctly deleted. After this commit they will be deleted.

This bug was almost certainly introduced in https://github.com/humanmade/backupwordpress/pull/936