### PR TITLE
Use preg_split to accomodate multiple delimiters

### DIFF
--- a/classes/backup/class-backup-utilities.php
+++ b/classes/backup/class-backup-utilities.php
@@ -78,7 +78,7 @@ class Backup_Utilities {
 		$suhosin_blacklist = array_map( 'trim', explode( ',', @call_user_func( $ini_get_callback, 'suhosin.executor.func.blacklist' ) ) );
 
 		// PHP supports disabling functions by adding them to `disable_functions` in php.ini.
-		$disabled_functions = array_map( 'trim', explode( ',', @call_user_func( $ini_get_callback, 'disable_functions' ) ) );
+		$disabled_functions = array_map( 'trim', preg_split( '/\s|,/', @call_user_func( $ini_get_callback, 'disable_functions' ) ) );
 
 		if ( in_array( $function, array_merge( $suhosin_blacklist, $disabled_functions ) ) ) {
 			return true;

--- a/tests/class-backup-utilities/test-exec-available.php
+++ b/tests/class-backup-utilities/test-exec-available.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace HM\BackUpWordPress;
+
+class Exec_Available_Tests extends \HM_Backup_UnitTestCase {
+
+	function ini_get_mock() {
+		return $this->disabled;
+	}
+
+	function test_nothing_disabled() {
+
+		$this->disabled = '';
+		$this->assertFalse( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+	}
+
+	function test_shell_exec_disabled() {
+
+		$this->disabled = 'shell_exec';
+		$this->assertFalse( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+	}
+
+	function test_only_exec_disabled() {
+
+		$this->disabled = 'exec';
+		$this->assertTrue( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+	}
+
+	function test_multiple_disabled_comma_delimited() {
+
+		$this->disabled = 'exec,shell_exec';
+		$this->assertTrue( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+		$this->disabled = 'shell_exec,exec,proc_open';
+		$this->assertTrue( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+	}
+
+	function test_multiple_disabled_space_delimited() {
+
+		$this->disabled = 'exec shell_exec';
+		$this->assertTrue( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+		$this->disabled = 'shell_exec exec proc_open';
+		$this->assertTrue( Backup_Utilities::is_function_disabled( 'exec', array( $this, 'ini_get_mock' ) ) );
+
+	}
+}


### PR DESCRIPTION
Fixes #994 