### PR TITLE
Requirements cleanup

### DIFF
--- a/classes/class-requirement.php
+++ b/classes/class-requirement.php
@@ -77,37 +77,8 @@ class Requirement_Zip_Archive extends Requirement {
 		return false;
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Zip_Archive', 'PHP' );
-
-/**
- * Class Requirement_Directory_Iterator_Follow_Symlinks
- *
- * Tests whether the FOLLOW_SYMLINKS class constant is available on Directory Iterator
- */
-class Requirement_Directory_Iterator_Follow_Symlinks extends Requirement {
-
-	/**
-	 * @var string
-	 */
-	var $name = 'DirectoryIterator FOLLOW_SYMLINKS';
-
-	/**
-	 * @return bool
-	 */
-	public static function test() {
-
-		if ( defined( 'RecursiveDirectoryIterator::FOLLOW_SYMLINKS' ) ) {
-			return true;
-		}
-
-		return false;
-
-	}
-
-}
-Requirements::register( 'HM\BackUpWordPress\Requirement_Directory_Iterator_Follow_Symlinks', 'PHP' );
 
 /**
  * Class Requirement_Zip_Command

--- a/classes/class-requirement.php
+++ b/classes/class-requirement.php
@@ -32,8 +32,9 @@ abstract class Requirement {
 
 		$test = $this->test();
 
-		if ( is_string( $test ) && $test )
+		if ( is_string( $test ) && $test ) {
 			return $test;
+		}
 
 		if ( is_bool( $test ) || empty( $test ) ) {
 
@@ -52,7 +53,6 @@ abstract class Requirement {
 	public function raw_result() {
 		return $this->test();
 	}
-
 }
 
 /**
@@ -131,7 +131,6 @@ class Requirement_Zip_Command_Path extends Requirement {
 		return $backup->get_zip_executable_path();
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Zip_Command_Path', 'Server' );
 
@@ -157,7 +156,6 @@ class Requirement_Mysqldump_Command_Path extends Requirement {
 		return $backup->get_mysqldump_executable_path();
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Mysqldump_Command_Path', 'Server' );
 
@@ -183,7 +181,6 @@ class Requirement_PHP_User extends Requirement {
 		return shell_exec( 'whoami' );
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_User', 'PHP' );
 
@@ -209,7 +206,6 @@ class Requirement_PHP_Group extends Requirement {
 		return shell_exec( 'groups' );
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_Group', 'PHP' );
 
@@ -229,7 +225,6 @@ class Requirement_PHP_Version extends Requirement {
 	public static function test() {
 		return PHP_VERSION;
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_Version', 'PHP' );
 
@@ -257,7 +252,6 @@ class Requirement_Cron_Array extends Requirement {
 		return $cron;
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Cron_Array', 'Site' );
 
@@ -290,7 +284,6 @@ class Requirement_Language extends Requirement {
 		return 'en_US';
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Language', 'Site' );
 
@@ -310,7 +303,6 @@ class Requirement_Safe_Mode extends Requirement {
 	public static function test() {
 		return Backup_Utilities::is_safe_mode_on();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Safe_Mode', 'PHP' );
 
@@ -330,7 +322,6 @@ class Requirement_Exec extends Requirement {
 	public static function test() {
 		return Backup_Utilities::is_exec_available();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Exec', 'PHP' );
 
@@ -350,7 +341,6 @@ class Requirement_PHP_Memory_Limit extends Requirement {
 	public static function test() {
 		return @ini_get( 'memory_limit' );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_Memory_Limit', 'PHP' );
 
@@ -370,7 +360,6 @@ class Requirement_Backup_Path extends Requirement {
 	public static function test() {
 		return Path::get_path();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Backup_Path', 'Site' );
 
@@ -390,7 +379,6 @@ class Requirement_Backup_Path_Permissions extends Requirement {
 	public static function test() {
 		return substr( sprintf( '%o', fileperms( Path::get_path() ) ), - 4 );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Backup_Path_Permissions', 'Site' );
 
@@ -410,7 +398,6 @@ class Requirement_WP_CONTENT_DIR extends Requirement {
 	public static function test() {
 		return WP_CONTENT_DIR;
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_WP_CONTENT_DIR', 'Site' );
 
@@ -430,7 +417,6 @@ class Requirement_WP_CONTENT_DIR_Permissions extends Requirement {
 	public static function test() {
 		return substr( sprintf( '%o', fileperms( WP_CONTENT_DIR ) ), - 4 );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_WP_CONTENT_DIR_Permissions', 'Site' );
 
@@ -450,7 +436,6 @@ class Requirement_ABSPATH extends Requirement {
 	public static function test() {
 		return ABSPATH;
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_ABSPATH', 'Site' );
 
@@ -470,7 +455,6 @@ class Requirement_Backup_Root_Path extends Requirement {
 	public static function test() {
 		return Path::get_root();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Backup_Root_Path', 'Site' );
 
@@ -500,13 +484,11 @@ class Requirement_Calculated_Size extends Requirement {
 			if ( $site_size->is_site_size_cached() ) {
 				$backup_sizes[ $schedule->get_type() ] = $site_size->get_formatted_site_size();
 			}
-
 		}
 
 		return $backup_sizes;
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Calculated_Size', 'Site' );
 
@@ -526,7 +508,6 @@ class Requirement_WP_Cron_Test extends Requirement {
 	public static function test() {
 		return (bool) get_option( 'hmbkp_wp_cron_test_failed' );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_WP_Cron_Test', 'Site' );
 
@@ -546,7 +527,6 @@ class Requirement_PHP_API extends Requirement {
 	public static function test() {
 		return php_sapi_name();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_API', 'PHP' );
 
@@ -565,13 +545,13 @@ class Requirement_Server_Software extends Requirement {
 	 */
 	public static function test() {
 
-		if ( ! empty( $_SERVER['SERVER_SOFTWARE'] ) )
+		if ( ! empty( $_SERVER['SERVER_SOFTWARE'] ) ) {
 			return $_SERVER['SERVER_SOFTWARE'];
+		}
 
 		return false;
 
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Server_Software', 'Server' );
 
@@ -591,7 +571,6 @@ class Requirement_Server_OS extends Requirement {
 	public static function test() {
 		return PHP_OS;
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Server_OS', 'Server' );
 
@@ -611,7 +590,6 @@ class Requirement_PHP_Disable_Functions extends Requirement {
 	public static function test() {
 		return @ini_get( 'disable_functions' );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_Disable_Functions', 'PHP' );
 
@@ -631,7 +609,6 @@ class Requirement_PHP_Open_Basedir extends Requirement {
 	public static function test() {
 		return @ini_get( 'open_basedir' );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_PHP_Open_Basedir', 'PHP' );
 
@@ -653,7 +630,6 @@ class Requirement_Define_HMBKP_PATH extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_PATH' ) ? HMBKP_PATH : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_PATH', 'constants' );
 
@@ -673,7 +649,6 @@ class Requirement_Define_HMBKP_ROOT extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_ROOT' ) ? HMBKP_ROOT : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_ROOT', 'constants' );
 
@@ -693,7 +668,6 @@ class Requirement_Define_HMBKP_MYSQLDUMP_PATH extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_MYSQLDUMP_PATH' ) ? HMBKP_MYSQLDUMP_PATH : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_MYSQLDUMP_PATH', 'constants' );
 
@@ -713,7 +687,6 @@ class Requirement_Define_HMBKP_ZIP_PATH extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_ZIP_PATH' ) ? HMBKP_ZIP_PATH : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_ZIP_PATH', 'constants' );
 
@@ -733,7 +706,6 @@ class Requirement_Define_HMBKP_CAPABILITY extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_CAPABILITY' ) ? HMBKP_CAPABILITY : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_CAPABILITY', 'constants' );
 
@@ -753,7 +725,6 @@ class Requirement_Define_HMBKP_EMAIL extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_EMAIL' ) ? HMBKP_EMAIL : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_EMAIL', 'constants' );
 
@@ -773,7 +744,6 @@ class Requirement_Define_HMBKP_ATTACHMENT_MAX_FILESIZE extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_ATTACHMENT_MAX_FILESIZE' ) ? HMBKP_ATTACHMENT_MAX_FILESIZE : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_ATTACHMENT_MAX_FILESIZE', 'constants' );
 
@@ -793,7 +763,6 @@ class Requirement_Define_HMBKP_EXCLUDE extends Requirement {
 	public static function test() {
 		return defined( 'HMBKP_EXCLUDE' ) ? HMBKP_EXCLUDE : '';
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Define_HMBKP_EXCLUDE', 'constants' );
 
@@ -801,10 +770,9 @@ class Requirement_Active_Plugins extends Requirement {
 
 	var $name = 'Active Plugins';
 
-	public static function test(){
+	public static function test() {
 		return get_option( 'active_plugins' );
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Active_Plugins', 'Site' );
 
@@ -812,10 +780,9 @@ class Requirement_Home_Url extends Requirement {
 
 	var $name = 'Home URL';
 
-	public static function test(){
+	public static function test() {
 		return home_url();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Home_Url', 'Site' );
 
@@ -826,7 +793,6 @@ class Requirement_Site_Url extends Requirement {
 	public static function test() {
 		return site_url();
 	}
-
 }
 Requirements::register( 'HM\BackUpWordPress\Requirement_Site_Url', 'Site' );
 
@@ -843,7 +809,7 @@ class Requirement_Max_Exec extends Requirement {
 
 	var $name = 'Max execution time';
 
-	public static function test(){
+	public static function test() {
 		return @ini_get( 'max_execution_time' );
 	}
 }


### PR DESCRIPTION
Drop the requirement check for `DirectoryIterator::Follow_Symlinks` as it's no longer used since we switched to Finder.

Also some WPCS fixes.