### PR TITLE
Switch to storing site size data in a file

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -536,7 +536,7 @@ function heartbeat_received( $response, $data ) {
 		if ( ! empty( $data['hmbkp_client_request'] ) ) {
 
 			// Pass the site size to be displayed when it's ready.
-			if ( Site_Size::is_site_size_cached() ) {
+			if ( Site_Size->is_site_size_cached() ) {
 
 				$site_size = new Site_Size( $schedule->get_type(),  $schedule->get_excludes() );
 

--- a/admin/actions.php
+++ b/admin/actions.php
@@ -535,10 +535,10 @@ function heartbeat_received( $response, $data ) {
 
 		if ( ! empty( $data['hmbkp_client_request'] ) ) {
 
-			// Pass the site size to be displayed when it's ready.
-			if ( Site_Size->is_site_size_cached() ) {
+			$site_size = new Site_Size( $schedule->get_type(),  $schedule->get_excludes() );
 
-				$site_size = new Site_Size( $schedule->get_type(),  $schedule->get_excludes() );
+			// Pass the site size to be displayed when it's ready.
+			if ( $site_size->is_site_size_cached() ) {
 
 				$response['hmbkp_site_size'] = $site_size->get_formatted_site_size();
 

--- a/admin/actions.php
+++ b/admin/actions.php
@@ -499,7 +499,7 @@ function calculate_site_size() {
 
 	$site_size = new Site_Size;
 
-	if ( ! $site_size::is_site_size_cached() ) {
+	if ( ! $site_size->is_site_size_cached() ) {
 		$root = new \SplFileInfo( Path::get_root() );
 		$site_size->filesize( $root );
 	}

--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -183,7 +183,7 @@ clear_settings_errors();
 
 						$site_size = new Site_Size;
 
-						if ( Site_Size::is_site_size_cached() ) {
+						if ( Site_Size->is_site_size_cached() ) {
 							printf( __( 'This schedule will store a maximum of %s of backups.', 'backupwordpress' ), '<code>' . esc_html( size_format( $site_size->get_site_size( $schedule->get_type(), $schedule->get_excludes() ) * $schedule->get_max_backups() ) ) . '</code>' );
 						} ?>
 

--- a/admin/schedule-form.php
+++ b/admin/schedule-form.php
@@ -183,7 +183,7 @@ clear_settings_errors();
 
 						$site_size = new Site_Size;
 
-						if ( Site_Size->is_site_size_cached() ) {
+						if ( $site_size->is_site_size_cached() ) {
 							printf( __( 'This schedule will store a maximum of %s of backups.', 'backupwordpress' ), '<code>' . esc_html( size_format( $site_size->get_site_size( $schedule->get_type(), $schedule->get_excludes() ) * $schedule->get_max_backups() ) ) . '</code>' );
 						} ?>
 

--- a/classes/backup/class-backup.php
+++ b/classes/backup/class-backup.php
@@ -85,7 +85,7 @@ class Backup {
 		// Set the file backup engine settings
 		foreach( $file_backup_engines as &$backup_engine ) {
 			$backup_engine->set_backup_filename( $this->backup_filename );
-			$backup_engine->set_excludes( new Excludes( array( '*.zip', 'index.html', '.htaccess', '.*-running' ) ) );
+			$backup_engine->set_excludes( new Excludes( array( '*.zip', 'index.html', '.htaccess', '.*-running', '.files' ) ) );
 		}
 
 		// Zip up the database dump

--- a/classes/class-path.php
+++ b/classes/class-path.php
@@ -456,6 +456,11 @@ class CleanUpIterator extends \FilterIterator {
 			return false;
 		}
 
+		// Don't remove the file manifest
+		if ( '.files' === $this->current()->getBasename() ) {
+			return false;
+		}
+
 		// Don't cleanup the backup running file
 		return ! preg_match( '/(.*-running)/', $this->current() );
 

--- a/classes/class-site-size.php
+++ b/classes/class-site-size.php
@@ -97,8 +97,8 @@ class Site_Size {
 	 *
 	 * @return bool
 	 */
-	public static function is_site_size_cached() {
-		return file_exists( Path::get_path() . '/.files' );
+	public function is_site_size_cached() {
+		return (bool) $this->get_cached_filesizes();
 	}
 
 	/**
@@ -226,20 +226,20 @@ class Site_Size {
 
 	}
 
-	public function get_cached_filesizes() {
+	public function get_cached_filesizes( $max_age = WEEK_IN_SECONDS ) {
 
 		$cache = PATH::get_path() . '/.files';
 		$files = false;
 
 		if ( file_exists( $cache ) ) {
-			$files = json_decode( gzuncompress( file_get_contents( $cache ) ), 'ARRAY_A' );
+
+			// If the file is old then regenerate it
+			if ( ( time() - filemtime( $cache ) ) <= $max_age ) {
+				$files = json_decode( gzuncompress( file_get_contents( $cache ) ), 'ARRAY_A' );
+			}
 		}
 
-		if ( is_array( $files ) ) {
-			return $files;
-		}
-
-		return false;
+		return $files;
 
 	}
 }

--- a/functions/core.php
+++ b/functions/core.php
@@ -261,7 +261,7 @@ function update() {
 		}
 	}
 
-	// Update from PRIOR_VERSION
+	// Update from 3.3.0
 	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( '3.3.0', get_option( 'hmbkp_plugin_version' ), '>' ) ) {
 
 		$schedules = Schedules::get_instance();
@@ -281,11 +281,16 @@ function update() {
 
 	}
 
+	// Update from 3.3.4
+	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( '3.4.0', get_option( 'hmbkp_plugin_version' ), '>' ) ) {
+		delete_transient( 'hmbkp_directory_filesizes' );
+	}
+
 	// Every update
 	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( Plugin::PLUGIN_VERSION, get_option( 'hmbkp_plugin_version' ), '>' ) ) {
 
 		require_once( HMBKP_PLUGIN_PATH . 'classes/class-setup.php' );
-		
+
 		\HMBKP_Setup::deactivate();
 
 		Path::get_instance()->protect_path( 'reset' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,6 +10,11 @@ if ( ! current_user_can( 'activate_plugins' ) ) {
 
 global $wpdb;
 
+// Delete the file manifest if it exists
+if ( file_exists( PATH::get_path() . '/.files' ) ) {
+	unlink( PATH::get_path() . '/.files' );
+}
+
 // Get all schedule options with a SELECT query and delete them.
 $schedules = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s", 'hmbkp_schedule_%' ) );
 


### PR DESCRIPTION
Instead of storing an array of all files and their associated filesizes in the DB in a transient we now store it in a hidden `.files` file.

The array of data is `json_encoded` into a string and then compressed with `gzcompress` this helps keep filesizes down.

Adds a unit test to ensure the file is only cached for a week.