### PR TITLE
Improve how filesizes are handled in the Your Site list

### DIFF
--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -17,56 +17,56 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 
 		<tbody>
 
-		<?php foreach ( $user_excludes as $key => $exclude ) :
+			<?php foreach ( $user_excludes as $key => $exclude ) :
 
-			$exclude_path = new \SplFileInfo( trailingslashit( Path::get_root() ) . ltrim( str_ireplace( Path::get_root(), '', $exclude ), '/' ) ); ?>
+				$exclude_path = new \SplFileInfo( trailingslashit( Path::get_root() ) . ltrim( str_ireplace( Path::get_root(), '', $exclude ), '/' ) ); ?>
 
-			<tr>
+				<tr>
 
-				<th scope="row">
+					<th scope="row">
 
-					<?php if ( $exclude_path->isFile() ) { ?>
+						<?php if ( $exclude_path->isFile() ) { ?>
 
-						<div class="dashicons dashicons-media-default"></div>
+							<div class="dashicons dashicons-media-default"></div>
 
-					<?php } elseif ( $exclude_path->isDir() ) { ?>
+						<?php } elseif ( $exclude_path->isDir() ) { ?>
 
-						<div class="dashicons dashicons-portfolio"></div>
+							<div class="dashicons dashicons-portfolio"></div>
 
-					<?php } ?>
+						<?php } ?>
 
-				</th>
+					</th>
 
-				<td>
+					<td>
 
-					<code><?php echo esc_html( str_ireplace( Path::get_root(), '', $exclude ) ); ?></code>
+						<code><?php echo esc_html( str_ireplace( Path::get_root(), '', $exclude ) ); ?></code>
 
-				</td>
+					</td>
 
-				<td>
+					<td>
 
-					<?php if ( ( in_array( $exclude, $excludes->get_default_excludes() ) ) || ( Path::get_path() === trailingslashit( Path::get_root() ) . untrailingslashit( $exclude ) ) ) : ?>
+						<?php if ( ( in_array( $exclude, $excludes->get_default_excludes() ) ) || ( Path::get_path() === trailingslashit( Path::get_root() ) . untrailingslashit( $exclude ) ) ) : ?>
 
-						<?php _e( 'Default rule', 'backupwordpress' ); ?>
+							<?php _e( 'Default rule', 'backupwordpress' ); ?>
 
-					<?php elseif ( defined( 'HMBKP_EXCLUDE' ) && false !== strpos( HMBKP_EXCLUDE, $exclude ) ) : ?>
+						<?php elseif ( defined( 'HMBKP_EXCLUDE' ) && false !== strpos( HMBKP_EXCLUDE, $exclude ) ) : ?>
 
-						<?php _e( 'Defined in wp-config.php', 'backupwordpress' ); ?>
+							<?php _e( 'Defined in wp-config.php', 'backupwordpress' ); ?>
 
-					<?php else : ?>
+						<?php else : ?>
 
-						<a href="<?php echo admin_action_url( 'remove_exclude_rule', array(
-							'hmbkp_remove_exclude' => $exclude,
-							'hmbkp_schedule_id'    => $schedule->get_id(),
-						) ); ?>" class="delete-action"><?php _e( 'Stop excluding', 'backupwordpress' ); ?></a>
+							<a href="<?php echo admin_action_url( 'remove_exclude_rule', array(
+								'hmbkp_remove_exclude' => $exclude,
+								'hmbkp_schedule_id'    => $schedule->get_id(),
+							) ); ?>" class="delete-action"><?php _e( 'Stop excluding', 'backupwordpress' ); ?></a>
 
-					<?php endif; ?>
+						<?php endif; ?>
 
-				</td>
+					</td>
 
-			</tr>
+				</tr>
 
-		<?php endforeach; ?>
+			<?php endforeach; ?>
 
 		</tbody>
 
@@ -171,11 +171,15 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 
 				<td>
 
-					<code><?php if ( is_link( Path::get_root() ) ) {
-						_e( 'Symlink', 'backupwordpress' );
-					} elseif ( is_dir( Path::get_root() ) ) {
-						_e( 'Folder', 'backupwordpress' );
-					} ?></code>
+					<code>
+
+						<?php if ( is_link( Path::get_root() ) ) {
+							_e( 'Symlink', 'backupwordpress' );
+						} elseif ( is_dir( Path::get_root() ) ) {
+							_e( 'Folder', 'backupwordpress' );
+						} ?>
+
+					</code>
 
 				</td>
 

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -93,10 +93,11 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 
 	$exclude_string = implode( '|', $excludes->get_excludes_for_regex() );
 
-	$site_size = new Site_Size;
+	$site_size = new Site_Size( 'file' );
+	$excluded_site_size = new Site_Size( 'file', $excludes );
 
 	// Kick off a recursive filesize scan
-	$files = list_directory_by_total_filesize( $directory ); ?>
+	$files = list_directory_by_total_filesize( $directory, $excludes ); ?>
 
 	<table class="widefat">
 
@@ -105,7 +106,7 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 			<tr>
 				<th></th>
 				<th scope="col"><?php _e( 'Name', 'backupwordpress' ); ?></th>
-				<th scope="col" class="column-format"><?php _e( 'Size', 'backupwordpress' ); ?></th>
+				<th scope="col" class="column-format"><?php _e( 'Included Size', 'backupwordpress' ); ?></th>
 				<th scope="col" class="column-format"><?php _e( 'Permissions', 'backupwordpress' ); ?></th>
 				<th scope="col" class="column-format"><?php _e( 'Type', 'backupwordpress' ); ?></th>
 				<th scope="col" class="column-format"><?php _e( 'Status', 'backupwordpress' ); ?></th>
@@ -154,40 +155,32 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 						$root = new \SplFileInfo( Path::get_root() );
 
 						$size = $site_size->filesize( $root );
-
-						if ( false !== $size ) {
-
-							$size = size_format( $size );
-
-							if ( ! $size ) {
-								$size = '0 B';
-							} ?>
+						$excluded_size = $excluded_site_size->filesize( $root ); ?>
 
 							<code>
 
-								<?php echo esc_html( $size ); ?>
+								<?php
+								echo ( preg_replace( '/[0-9]+/', '', size_format( $size ) ) === preg_replace( '/[0-9]+/', '', size_format( $excluded_size ) ) ) ? esc_html( (int) size_format( $excluded_size ) ) : esc_html( size_format( $excluded_size ) );
+								echo ' of ' . esc_html( size_format( $size ) );
+								?>
 
-								<a class="dashicons dashicons-update"
-								   href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize',  urlencode( Path::get_root() ) ), 'hmbkp-recalculate_directory_filesize' ) ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
+								<a class="dashicons dashicons-update" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize',  urlencode( Path::get_root() ) ), 'hmbkp-recalculate_directory_filesize' ) ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
 
 							</code>
-
-
-						<?php } ?>
 
 					<?php } ?>
 
 				<td>
-					<?php echo esc_html( substr( sprintf( '%o', fileperms( Path::get_root() ) ), - 4 ) ); ?>
+					<code><?php echo esc_html( substr( sprintf( '%o', fileperms( Path::get_root() ) ), - 4 ) ); ?></code>
 				</td>
 
 				<td>
 
-					<?php if ( is_link( Path::get_root() ) ) {
+					<code><?php if ( is_link( Path::get_root() ) ) {
 						_e( 'Symlink', 'backupwordpress' );
 					} elseif ( is_dir( Path::get_root() ) ) {
 						_e( 'Folder', 'backupwordpress' );
-					} ?>
+					} ?></code>
 
 				</td>
 
@@ -265,19 +258,19 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 
 							if ( false !== $size ) {
 
-								$size = size_format( $size );
-
-								if ( ! $size ) {
-									$size = '0 B';
-								} ?>
+								$size = size_format( $size ) ?: '0 B';
+								$excluded_size = size_format( $excluded_site_size->filesize( $file ) ) ?: '0'; ?>
 
 								<code>
 
-									<?php echo esc_html( $size ); ?>
-
-									<?php if ( $file->isDir() ) { ?>
-										<a title="<?php _e( 'Recalculate the size of this directory', 'backupwordpress' ); ?>" class="dashicons dashicons-update" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize', urlencode( wp_normalize_path( $file->getPathname() ) ) ), 'hmbkp-recalculate_directory_filesize' ) ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
-									<?php } ?>
+									<?php if ( $file->isDir() ) {
+										echo ( preg_replace( '/[0-9]+/', '', $size ) === preg_replace( '/[0-9]+/', '', $excluded_size ) ) ? esc_html( (int) $excluded_size ) : esc_html( $excluded_size );
+										echo ' of ' . esc_html( $size );
+									} elseif ( ! $is_unreadable ) {
+										echo esc_html( $size );
+									} else {
+										echo '-';
+									} ?>
 
 								</code>
 
@@ -291,13 +284,17 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 					</td>
 
 					<td>
-						<?php if ( ! $is_unreadable ) {
-							echo esc_html( substr( sprintf( '%o', $file->getPerms() ), - 4 ) );
-						} ?>
+						<code>
+							<?php if ( ! $is_unreadable ) {
+								echo esc_html( substr( sprintf( '%o', $file->getPerms() ), - 4 ) );
+							} else {
+								echo '-';
+							} ?>
+						</code>
 					</td>
 
 					<td>
-
+						<code>
 						<?php if ( $file->isLink() ) { ?>
 
 							<span title="<?php echo esc_attr( wp_normalize_path( $file->getRealPath() ) ); ?>"><?php _e( 'Symlink', 'backupwordpress' ); ?></span>
@@ -307,7 +304,7 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 						} else {
 							_e( 'File', 'backupwordpress' );
 						} ?>
-
+						</code>
 					</td>
 
 					<td class="column-format">

--- a/admin/schedule-form-excludes.php
+++ b/admin/schedule-form-excludes.php
@@ -158,14 +158,9 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 						$excluded_size = $excluded_site_size->filesize( $root ); ?>
 
 							<code>
-
-								<?php
-								echo ( preg_replace( '/[0-9]+/', '', size_format( $size ) ) === preg_replace( '/[0-9]+/', '', size_format( $excluded_size ) ) ) ? esc_html( (int) size_format( $excluded_size ) ) : esc_html( size_format( $excluded_size ) );
-								echo ' of ' . esc_html( size_format( $size ) );
-								?>
-
+								<?php $excluded_size = is_same_size_format( $size, $excluded_size ) ? (int) size_format( $excluded_size ) : size_format( $excluded_size ); ?>
+								<?php echo sprintf( __( '%s of %s', 'backupwordpress' ), esc_html( $excluded_size ), esc_html( size_format( $size ) ) ); ?>
 								<a class="dashicons dashicons-update" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'hmbkp_recalculate_directory_filesize',  urlencode( Path::get_root() ) ), 'hmbkp-recalculate_directory_filesize' ) ); ?>"><span><?php _e( 'Refresh', 'backupwordpress' ); ?></span></a>
-
 							</code>
 
 					<?php } ?>
@@ -264,8 +259,8 @@ $user_excludes = $excludes->get_user_excludes(); ?>
 								<code>
 
 									<?php if ( $file->isDir() ) {
-										echo ( preg_replace( '/[0-9]+/', '', $size ) === preg_replace( '/[0-9]+/', '', $excluded_size ) ) ? esc_html( (int) $excluded_size ) : esc_html( $excluded_size );
-										echo ' of ' . esc_html( $size );
+										$excluded_size = is_same_size_format( $size, $excluded_size ) ? (int) size_format( $excluded_size ) : size_format( $excluded_size );
+										echo sprintf( __( '%s of %s', 'backupwordpress' ), esc_html( $excluded_size ), esc_html( size_format( $size ) ) );
 									} elseif ( ! $is_unreadable ) {
 										echo esc_html( $size );
 									} else {

--- a/classes/class-scheduled-backup.php
+++ b/classes/class-scheduled-backup.php
@@ -287,7 +287,7 @@ class Scheduled_Backup {
 	/**
 	 * Set the schedule start time.
 	 *
-	 * @param timestamp $time
+	 * @param Int $time A valid timestamp
 	 */
 	public function set_schedule_start_time( $time ) {
 

--- a/functions/core.php
+++ b/functions/core.php
@@ -285,7 +285,7 @@ function update() {
 	if ( get_option( 'hmbkp_plugin_version' ) && version_compare( Plugin::PLUGIN_VERSION, get_option( 'hmbkp_plugin_version' ), '>' ) ) {
 
 		require_once( HMBKP_PLUGIN_PATH . 'classes/class-setup.php' );
-		
+
 		\HMBKP_Setup::deactivate();
 
 		Path::get_instance()->protect_path( 'reset' );
@@ -608,7 +608,7 @@ function ignore_stderr() {
  * @todo doesn't really belong in this class, should just be a function
  * @return array            returns an array of files ordered by filesize
  */
-function list_directory_by_total_filesize( $directory ) {
+function list_directory_by_total_filesize( $directory, Excludes $excludes ) {
 
 	$files = $files_with_no_size = $empty_files = $files_with_size = $unreadable_files = array();
 
@@ -622,7 +622,7 @@ function list_directory_by_total_filesize( $directory ) {
 	$finder->ignoreUnreadableDirs();
 	$finder->depth( '== 0' );
 
-	$site_size = new Site_Size;
+	$site_size = new Site_Size( 'file', $excludes );
 
 	$files = $finder->in( $directory );
 

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -208,8 +208,8 @@ function plugin_row( $plugins ) {
 
 	$menu = is_multisite() ? 'Settings' : 'Tools';
 
-	if ( isset( $plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php'] ) ) {
-		$plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php']['Description'] = str_replace( 'Once activated you\'ll find me under <strong>' . $menu . ' &rarr; Backups</strong>', 'Find me under <strong><a href="' . esc_url( get_settings_url() ) . '">' . $menu . ' &rarr; Backups</a></strong>', $plugins[HMBKP_PLUGIN_SLUG . '/backupwordpress.php']['Description'] );
+	if ( isset( $plugins[ HMBKP_PLUGIN_SLUG . '/backupwordpress.php' ] ) ) {
+		$plugins[ HMBKP_PLUGIN_SLUG . '/backupwordpress.php' ]['Description'] = str_replace( 'Once activated you\'ll find me under <strong>' . $menu . ' &rarr; Backups</strong>', 'Find me under <strong><a href="' . esc_url( get_settings_url() ) . '">' . $menu . ' &rarr; Backups</a></strong>', $plugins[ HMBKP_PLUGIN_SLUG . '/backupwordpress.php' ]['Description'] );
 	}
 
 	return $plugins;
@@ -312,7 +312,7 @@ function translated_schedule_title( $slug, $title ) {
 		'database-monthly'     => esc_html__( 'Database Monthly', 'backupwordpress' ),
 		'complete-manually'    => esc_html__( 'Complete Manually', 'backupwordpress' ),
 		'file-manually'        => esc_html__( 'File Manually', 'backupwordpress' ),
-		'database-manually'    => esc_html__( 'Database Manually', 'backupwordpress' )
+		'database-manually'    => esc_html__( 'Database Manually', 'backupwordpress' ),
 	);
 
 	if ( isset( $titles[ $slug ] ) ) {
@@ -379,7 +379,7 @@ function get_settings_errors() {
  *
  * @return bool
  */
-function clear_settings_errors(){
+function clear_settings_errors() {
 	return delete_transient( 'hmbkp_settings_errors' );
 }
 

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -412,3 +412,23 @@ function path_in_php_open_basedir( $path, $ini_get = 'ini_get' ) {
 	return false;
 
 }
+
+/**
+ * Check if two filesizes are of the same size format
+ *
+ * E.g. 22 MB and 44 MB are both MB so return true. Whereas
+ * 22 KB and 12 TB are not so return false.
+ *
+ * @param  int  $size
+ * @param  int  $other_size
+ *
+ * @return boolean             Whether the two filesizes are of the same magnitude
+ */
+function is_same_size_format( $size, $other_size ) {
+
+	if ( ! is_int( $size ) || ! is_int( $other_size ) ) {
+		return false;
+	}
+
+	return preg_replace( '/[0-9]+/', '', size_format( $size ) ) === preg_replace( '/[0-9]+/', '', size_format( $other_size ) );
+}

--- a/tests/test-is-same-size-format.php
+++ b/tests/test-is-same-size-format.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace HM\BackUpWordPress;
+
+class Is_Same_Size_Format_Tests extends \HM_Backup_UnitTestCase {
+
+	public function test_both_same_size() {
+		$this->assertTrue( is_same_size_format( 22000000, 22000000 ) );
+	}
+
+	public function test_not_both_same_size() {
+		$this->assertFalse( is_same_size_format( 22000, 22000000 ) );
+	}
+
+	public function test_both_strings() {
+		$this->assertFalse( is_same_size_format( '22', '22' ) );
+	}
+}


### PR DESCRIPTION
- The list of files and folders is now ordered by the included filesize, that is the total filesize minus any excludes
- We now display the included filesize for directories in the format "Included size of total size".
- All cells in the table are now wrapped in `<code>` tags
- Unreadable files now show `-` for size and permissions to indicate that we don't actually have the data

Here's how that looks:

<img width="1086" alt="screen shot 2016-03-01 at 00 01 50" src="https://cloud.githubusercontent.com/assets/308507/13413218/ddbbc440-df40-11e5-9e6a-4c8ee00a18cc.png">
