### PR TITLE
Fix a notice on Uninstall and ensure all options are removed

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,9 +12,11 @@ global $wpdb;
 
 require_once dirname( __FILE__ ) . '/classes/class-path.php';
 
+$path = HM\BackUpWordPress\PATH::get_instance()->get_existing_path();
+
 // Delete the file manifest if it exists
-if ( file_exists( HM\BackUpWordPress\PATH::get_path() . '/.files' ) ) {
-	unlink( HM\BackUpWordPress\PATH::get_path() . '/.files' );
+if ( file_exists( $path . '/.files' ) ) {
+	unlink( $path . '/.files' );
 }
 
 // Get all schedule options with a SELECT query and delete them.
@@ -23,7 +25,7 @@ $schedules = $wpdb->get_col( $wpdb->prepare( "SELECT option_name FROM $wpdb->opt
 array_map( 'delete_option', $schedules );
 
 // Remove all the options
-array_map( 'delete_option', array( 'hmbkp_enable_support', 'hmbkp_plugin_version', 'hmbkp_path', 'hmbkp_default_path', 'hmbkp_upsell' ) );
+array_map( 'delete_option', array( 'hmbkp_enable_support', 'hmbkp_plugin_version', 'hmbkp_path', 'hmbkp_default_path', 'hmbkp_upsell', 'hmbkp_notices' ) );
 
 // Delete all transients
 array_map( 'delete_transient', array( 'hmbkp_plugin_data', 'hmbkp_directory_filesizes', 'hmbkp_directory_filesize_running', 'timeout_hmbkp_wp_cron_test_beacon', 'hmbkp_wp_cron_test_beacon' ) );


### PR DESCRIPTION
Use `get_existing_path` rather than calling `get_path` directly so that we avoid
calling code which relies on `HMBKP_SECURE_KEY`.

Fixes https://github.com/humanmade/backupwordpress/issues/1021