### PR TITLE
Improve error handling when there's no backup methods supported

### DIFF
--- a/functions/core.php
+++ b/functions/core.php
@@ -426,6 +426,14 @@ function is_backup_possible() {
 		return false;
 	}
 
+	if ( ! Requirement_Mysqldump_Command_Path::test() && ! Requirement_PDO::test() ) {
+		return false;
+	}
+
+	if ( ! Requirement_Zip_Command_Path::test() && ! Requirement_Zip_Archive::test() ) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -85,15 +85,13 @@ function admin_notices() {
 
 			</ul>
 
-			<button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'backupwordpress' ); ?></span></button>
-
 		</div>
 
 	<?php endif; ?>
 
 	<?php if ( ! empty( $notices['server_config'] ) ) : ?>
 
-		<div id="hmbkp-warning-server" class="error notice is-dismissible">
+		<div id="hmbkp-warning-server" class="error notice">
 
 			<ul>
 
@@ -104,8 +102,6 @@ function admin_notices() {
 				<?php endforeach; ?>
 
 			</ul>
-
-			<button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'backupwordpress' ); ?></span></button>
 
 		</div>
 
@@ -126,8 +122,6 @@ function admin_notices() {
 						<p><?php echo wp_kses_data( $msg ); ?></p>
 
 					<?php endforeach; ?>
-
-					<button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'backupwordpress' ); ?></span></button>
 
 				</div>
 
@@ -188,7 +182,11 @@ function set_server_config_notices() {
 	}
 
 	if ( ! Requirement_Mysqldump_Command_Path::test() && ! Requirement_PDO::test() ) {
-		$messages[] = sprintf( __( 'Your database cannot be backed up because your server doesn\'t support %1$s or %2$s. Please contact your host and ask them to enable them.', 'backupwordpress' ), '<code>mysqldump</code>', '<code>PDO</code>' );
+		$messages[] = sprintf( __( 'Your site cannot be backed up because your server doesn\'t support %1$s or %2$s. Please contact your host and ask them to enable them.', 'backupwordpress' ), '<code>mysqldump</code>', '<code>PDO::mysql</code>' );
+	}
+
+	if ( ! Requirement_Zip_Command_Path::test() && ! Requirement_Zip_Archive::test() ) {
+		$messages[] = sprintf( __( 'Your site cannot be backed up because your server doesn\'t support %1$s or %2$s. Please contact your host and ask them to enable them.', 'backupwordpress' ), '<code>zip</code>', '<code>ZipArchive</code>' );
 	}
 
 	if ( count( $messages ) > 0 ) {


### PR DESCRIPTION
- Add checks for `mysqldump`/`PDO` as well as `zip`/`ZipArchive` to `hmbkp_possible`. This blocks usage of the plugin if no backup engines are supported.
- Show an error message if there's no zip methods.
- No need to output the dismiss button html as it's inserted automatically.
- Server errors shouldn't be dismissible as they persist until they're fixed.

Fixes https://github.com/humanmade/backupwordpress/issues/935