### PR TITLE
Add unit tests for the Notices class and fix bugs

### DIFF
--- a/assets/hmbkp.js
+++ b/assets/hmbkp.js
@@ -121,7 +121,7 @@ var BackUpWordPressAdmin = (function($){
 
 		} );
 
-		$( document ).on( 'click', '#hmbkp-warning-backup .notice-dismiss', function(){
+		$( document ).on( 'click', '[id^="hmbkp-warning-"] .notice-dismiss', function(){
 			$.post(
 				ajaxurl,
 				{

--- a/classes/class-notices.php
+++ b/classes/class-notices.php
@@ -23,7 +23,7 @@ class Notices {
 	/**
 	 * Contains the instantiated Notices instance
 	 *
-	 * @var Path $this->get_instance
+	 * @var Notices $this->get_instance
 	 */
 	private static $instance;
 

--- a/classes/class-notices.php
+++ b/classes/class-notices.php
@@ -115,9 +115,9 @@ class Notices {
 
 		$notices = $this->get_all_notices();
 
-		if ( $notices ) {
+		if ( ! empty( $notices ) ) {
 
-			if ( $context ) {
+			if ( ! empty( $context ) ) {
 				return isset( $notices[ $context ] ) ? $notices[ $context ] : array();
 			}
 

--- a/classes/class-notices.php
+++ b/classes/class-notices.php
@@ -2,7 +2,6 @@
 
 namespace HM\BackUpWordPress;
 
-
 /**
  * Class for managing notices
  *
@@ -68,9 +67,9 @@ class Notices {
 	 *
 	 * @param string  $context    The context of the notice message
 	 * @param array   $messages   The array of messages
-	 * @param boolean $persistant Whether the notice should persist via the database. Defaults to true.
+	 * @param boolean $persistent Whether the notice should persist via the database. Defaults to true.
 	 */
-	public function set_notices( $context, array $messages, $persistant = true ) {
+	public function set_notices( $context, array $messages, $persistent = true ) {
 
 		// Clear any empty messages and avoid duplicates
 		$messages = array_unique( array_filter( $messages ) );
@@ -81,9 +80,9 @@ class Notices {
 
 		$this->notices[ $context ] = array_merge( $this->get_notices( $context ), $messages );
 
-		if ( $persistant ) {
+		if ( $persistent ) {
 
-			$new_notices = $notices = $this->get_persistant_notices();
+			$new_notices = $notices = $this->get_persistent_notices();
 
 			// Make sure we merge in any existing notices
 			if ( ! empty( $notices[ $context ] ) ) {
@@ -130,20 +129,20 @@ class Notices {
 	}
 
 	/**
-	 * Get both standard and persistant notices
+	 * Get both standard and persistent notices
 	 *
 	 * @return array The array of contexts and notices
 	 */
 	private function get_all_notices() {
-		return array_map( 'array_unique', array_merge_recursive( $this->notices, $this->get_persistant_notices() ) );
+		return array_map( 'array_unique', array_merge_recursive( $this->notices, $this->get_persistent_notices() ) );
 	}
 
 	/**
-	 * Load the persistant notices from the database
+	 * Load the persistent notices from the database
 	 *
 	 * @return array The array of notices
 	 */
-	private function get_persistant_notices() {
+	private function get_persistent_notices() {
 		$notices = get_option( 'hmbkp_notices' );
 		if ( ! empty( $notices ) ) {
 			return $notices;
@@ -152,7 +151,7 @@ class Notices {
 	}
 
 	/**
-	 * Clear all notices including persistant ones
+	 * Clear all notices including persistent ones
 	 */
 	public function clear_all_notices() {
 		$this->notices = array();

--- a/classes/class-notices.php
+++ b/classes/class-notices.php
@@ -2,62 +2,115 @@
 
 namespace HM\BackUpWordPress;
 
+
 /**
- * Class Notices
+ * Class for managing notices
+ *
+ * Notices are messages along with an associated context, by default
+ * they are stored in the db and thus persist between page loads.
  */
 class Notices {
 
 	/**
-	 * @var
-	 */
-	private static $_instance;
-
-	private $notices;
-
-	/**
+	 * The array of notice messages
 	 *
+	 * This is a multidimensional array of
+	 * `array( context => array( 'message' ) );``
+	 *
+	 * @var array
 	 */
-	private function __construct() {}
+	private $notices = array();
 
 	/**
-	 * @return Notices
+	 * Contains the instantiated Notices instance
+	 *
+	 * @var Path $this->get_instance
+	 */
+	private static $instance;
+
+	/**
+	 * Protected constructor to prevent creating a new instance of the
+	 * *Singleton* via the `new` operator from outside of this class.
+	 */
+	protected function __construct() {}
+
+	/**
+	 * Private clone method to prevent cloning of the instance of the
+	 * *Singleton* instance.
+	 */
+	private function __clone() {}
+
+	/**
+	 * Private unserialize method to prevent unserializing of the *Singleton*
+	 * instance.
+	 */
+	private function __wakeup() {}
+
+	/**
+	 * Returns the *Singleton* instance of this class.
+	 *
+	 * @staticvar Notices $instance The *Singleton* instances of this class.
+	 *
+	 * @return Notices The *Singleton* instance.
 	 */
 	public static function get_instance() {
 
-		if ( ! ( self::$_instance instanceof Notices ) ) {
-			self::$_instance = new Notices();
+		if ( ! ( self::$instance instanceof Notices ) ) {
+			self::$instance = new Notices();
 		}
 
-		return self::$_instance;
+		return self::$instance;
 
 	}
 
 	/**
-	 * @param string $context
-	 * @param array $messages
-	 * @param bool $persistant 		whether to save the notices to the database
+	 * Set an array of notice messages for a specific context
 	 *
-	 * @return mixed|void
+	 * @param string  $context    The context of the notice message
+	 * @param array   $messages   The array of messages
+	 * @param boolean $persistant Whether the notice should persist via the database. Defaults to true.
 	 */
 	public function set_notices( $context, array $messages, $persistant = true ) {
 
-		$this->notices[ $context ] = $messages;
+		// Clear any empty messages and avoid duplicates
+		$messages = array_unique( array_filter( $messages ) );
+
+		if ( empty( $context ) || empty( $messages ) ) {
+			return false;
+		}
+
+		$this->notices[ $context ] = array_merge( $this->get_notices( $context ), $messages );
 
 		if ( $persistant ) {
-			$notices = get_option( 'hmbkp_notices' );
-			$notices[ $context ] = $messages;
-			update_option( 'hmbkp_notices', $notices );
+
+			$new_notices = $notices = $this->get_persistant_notices();
+
+			// Make sure we merge in any existing notices
+			if ( ! empty( $notices[ $context ] ) ) {
+				$new_notices[ $context ] = array_merge( $notices[ $context ], $messages );
+			} else {
+				$new_notices[ $context ] = $messages;
+			}
+
+			// Only update the database if the notice array has changed
+			if ( $new_notices !== $notices ) {
+				update_option( 'hmbkp_notices', $new_notices );
+			}
 		}
+
+		return true;
 
 	}
 
 	/**
-	 * Fetch the notices for the context.
-	 * All notices by default.
+	 * Fetch an array of notices messages
 	 *
-	 * @param string $context
+	 * If you specify a context then you'll just get messages for that context otherwise
+	 * you get multidimensional array of all contexts and their messages.
 	 *
-	 * @return array|mixed|void
+	 * @param string $context The context that you'd like the messages for
+	 *
+	 * @return array The array of notice messages
 	 */
 	public function get_notices( $context = '' ) {
 
@@ -65,8 +118,8 @@ class Notices {
 
 		if ( $notices ) {
 
-			if ( $context && isset( $notices[ $context ] ) ) {
-				return $notices[ $context ];
+			if ( $context ) {
+				return isset( $notices[ $context ] ) ? $notices[ $context ] : array();
 			}
 
 			return $notices;
@@ -76,19 +129,33 @@ class Notices {
 
 	}
 
+	/**
+	 * Get both standard and persistant notices
+	 *
+	 * @return array The array of contexts and notices
+	 */
 	private function get_all_notices() {
-		return array_merge_recursive( (array) $this->notices, (array) get_option( 'hmbkp_notices' ) );
+		return array_map( 'array_unique', array_merge_recursive( $this->notices, $this->get_persistant_notices() ) );
 	}
 
 	/**
-	 * Delete all notices from the DB.
+	 * Load the persistant notices from the database
+	 *
+	 * @return array The array of notices
 	 */
-	public function clear_all_notices() {
-
-		$this->notices = array();
-
-		delete_option( 'hmbkp_notices' );
-
+	private function get_persistant_notices() {
+		$notices = get_option( 'hmbkp_notices' );
+		if ( ! empty( $notices ) ) {
+			return $notices;
+		}
+		return array();
 	}
 
+	/**
+	 * Clear all notices including persistant ones
+	 */
+	public function clear_all_notices() {
+		$this->notices = array();
+		delete_option( 'hmbkp_notices' );
+	}
 }

--- a/classes/class-notices.php
+++ b/classes/class-notices.php
@@ -144,10 +144,7 @@ class Notices {
 	 */
 	private function get_persistent_notices() {
 		$notices = get_option( 'hmbkp_notices' );
-		if ( ! empty( $notices ) ) {
-			return $notices;
-		}
-		return array();
+		return ! empty( $notices ) ? $notices : array();
 	}
 
 	/**

--- a/tests/test-notices.php
+++ b/tests/test-notices.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace HM\BackUpWordPress;
+
+class Notice_Tests extends \HM_Backup_UnitTestCase {
+
+	public function setUp() {
+		$this->notices = Notices::get_instance();
+	}
+
+	public function tearDown() {
+		$this->notices->clear_all_notices();
+		$this->reset_notices();
+	}
+
+	public function test_no_notices_no_context() {
+		$this->assertEquals( array(), $this->notices->get_notices() );
+	}
+
+	public function test_no_notices_context() {
+		$this->assertEquals( array(), $this->notices->get_notices( 'foo' ) );
+	}
+
+	public function test_set_single_notice_with_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->assertEquals( array( 'bar' ), $this->notices->get_notices( 'foo' ) );
+	}
+
+	public function test_get_notices_with_wrong_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->assertEquals( array(), $this->notices->get_notices( 'bar' ) );
+	}
+
+	public function test_empty_context() {
+		$this->notices->set_notices( '', array( 'bar' ), false );
+		$this->assertEquals( array(), $this->notices->get_notices() );
+	}
+
+	public function test_empty_message() {
+		$this->notices->set_notices( 'foo', array( '' ), false );
+		$this->assertEquals( array(), $this->notices->get_notices() );
+	}
+
+	public function test_set_multiple_notice_with_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->notices->set_notices( 'fizz', array( 'buzz' ), false );
+		$this->assertEquals( array( 'bar' ), $this->notices->get_notices( 'foo' ) );
+		$this->assertEquals( array( 'buzz' ), $this->notices->get_notices( 'fizz' ) );
+		$this->assertEquals( array( 'foo' => array( 'bar' ), 'fizz' => array( 'buzz' ) ), $this->notices->get_notices() );
+	}
+
+	public function test_set_multiple_notices_in_same_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->notices->set_notices( 'foo', array( 'baz' ), false );
+		$this->assertEquals( array( 'bar', 'baz' ), $this->notices->get_notices( 'foo' ) );
+	}
+
+	public function test_set_multiple_persistant_notices_in_same_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), true );
+		$this->notices->set_notices( 'foo', array( 'baz' ), true );
+		$this->reset_notices();
+		$this->assertEquals( array( 'bar', 'baz' ), $this->notices->get_notices( 'foo' ) );
+	}
+
+	public function test_set_duplicate_notice() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->assertEquals( array( 'bar' ), $this->notices->get_notices( 'foo' ) );
+	}
+
+	public function test_set_duplicate_notices_different_contexts() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->notices->set_notices( 'baz', array( 'bar' ), false );
+		$this->assertEquals( array( 'foo' => array( 'bar' ), 'baz' => array( 'bar' ) ), $this->notices->get_notices() );
+	}
+
+	public function test_clear_notices() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), false );
+		$this->notices->clear_all_notices();
+		$this->assertEquals( array(), $this->notices->get_notices( 'bar' ) );
+		$this->assertEquals( array(), $this->notices->get_notices() );
+	}
+
+	public function test_persistant_notice() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), true );
+		$this->reset_notices();
+		$this->assertEquals( array( 'bar' ), $this->notices->get_notices( 'foo' ) );
+
+	}
+
+	public function test_set_persistant_single_notice_with_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), true );
+		$this->reset_notices();
+		$this->assertEquals( array( 'bar' ), $this->notices->get_notices( 'foo' ) );
+	}
+
+	public function test_get_persistant_notices_with_wrong_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), true );
+		$this->reset_notices();
+		$this->assertEquals( array(), $this->notices->get_notices( 'bar' ) );
+	}
+
+	public function test_set_persistant_multiple_notice_with_context() {
+		$this->notices->set_notices( 'foo', array( 'bar' ), true );
+		$this->notices->set_notices( 'fizz', array( 'buzz' ), true );
+		$this->reset_notices();
+		$this->assertEquals( array( 'bar' ), $this->notices->get_notices( 'foo' ) );
+		$this->assertEquals( array( 'buzz' ), $this->notices->get_notices( 'fizz' ) );
+		$this->assertEquals( array( 'foo' => array( 'bar' ), 'fizz' => array( 'buzz' ) ), $this->notices->get_notices() );
+	}
+
+	private function reset_notices() {
+		$reflection = new \ReflectionClass( Notices::get_instance() );
+		$instance = $reflection->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+		$instance->setAccessible( false );
+		$this->notices = Notices::get_instance();
+	}
+}


### PR DESCRIPTION
This PR fixes up a bunch of issues in the Notices class and adds full unit test coverage. Issues resolved:

 * `(array) get_option` returned an array with a single empty element rather than an empty array.
 * Setting a persistent notice duplicated it as it was then in `$this->notices` and the database.
 * Calling `get_notices` with a context which didn't exist returned all notices rather than none.
 * Calling `set_notices` multiple times with same context overwrote all but the last messages.
 * It was possible to set broken messages with empty context or message.
 * `update_option` was needlessly called when setting a message that had already previously been set.


It also completes the docblocks and brings the Singleton pattern inline with Path.


- [x] Persistent notices aren't dismissible.