### PR TITLE
Corrects logic and improves error conditions in disk_low_space

### DIFF
--- a/functions/interface.php
+++ b/functions/interface.php
@@ -442,7 +442,7 @@ function is_same_size_format( $size, $other_size ) {
  */
 function disk_space_low( $backup_size = false ) {
 
-	$disk_space = disk_free_space( Path::get_path() );
+	$disk_space = @disk_free_space( Path::get_path() );
 
 	if ( ! $disk_space ) {
 		return false;

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -442,19 +442,23 @@ function is_same_size_format( $size, $other_size ) {
  */
 function disk_space_low( $backup_size = false ) {
 
+	$disk_space = disk_free_space( Path::get_path() );
+
+	if ( ! $disk_space ) {
+		return false;
+	}
+
 	if ( ! $backup_size ) {
 
 		$site_size = new Site_Size();
 
-		if ( $site_size->is_site_size_cached() ) {
+		if ( ! $site_size->is_site_size_cached() ) {
 			return false;
 		}
 
 		$backup_size = $site_size->get_site_size() * 2;
 
 	}
-
-	$disk_space = disk_free_space( Path::get_path() );
 
 	return $backup_size >= $disk_space;
 


### PR DESCRIPTION
- Correct check for is_site_size_cached to ensure we only continue if it is cached.
- Check the return value of disk_free_space to ensure it's valid.

Fixes https://github.com/humanmade/backupwordpress/issues/1050