### PR TITLE
Exclude codecov.yml from the final plugin build for WP org

### DIFF
--- a/grunt/excludes
+++ b/grunt/excludes
@@ -24,3 +24,4 @@ CONTRIBUTING.md
 changelog.txt
 .scrutinizer.yml
 phpunit.xml
+codecov.yml


### PR DESCRIPTION
#1086 