### PR TITLE
Add some help text for changing your backup path

### DIFF
--- a/admin/schedule-sentence.php
+++ b/admin/schedule-sentence.php
@@ -73,8 +73,7 @@ switch ( $schedule->get_reoccurrence() ) :
 
 endswitch;
 
-$server = '<span title="' . esc_attr( Path::get_path() ) . '">' . __( 'this server', 'backupwordpress' ) . '</span>';
-$server = '<code>' . esc_attr( str_replace( Path::get_home_path(), '', Path::get_path() ) ) . '</code>';
+$server = '<code title="' . __( 'Check the help tab to learn how to change where your backups are stored.', 'backupwordpress' ) . '">' . esc_attr( str_replace( Path::get_home_path(), '', Path::get_path() ) ) . '</code>';
 
 // Backup to keep
 switch ( $schedule->get_max_backups() ) :


### PR DESCRIPTION
Adds some simple help text to the title tag on the backup path that's shown in the schedule sentence.

<img width="697" alt="screen shot 2016-08-28 at 22 44 26" src="https://cloud.githubusercontent.com/assets/308507/18036967/055bca90-6d71-11e6-8376-3ef8043eba31.png">

See https://github.com/humanmade/backupwordpress/issues/1091