### PR TITLE
Extension version text on Extensions page

### DIFF
--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -1,19 +1,12 @@
 <?php
-
 namespace HM\BackUpWordPress;
-
 include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-
 ?>
 
 <div class="wrap">
-
 	<h1>
-
 		<a class="page-title-action" href="<?php echo esc_url( get_settings_url() ); ?>"><?php esc_html_e( '&larr; Backups', 'backupwordpress' ); ?></a>
-
 		<?php esc_html_e( 'BackUpWordPress Extensions', 'backupwordpress' ); ?>
-
 	</h1>
 
 	<div class="wp-filter">
@@ -43,7 +36,6 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	<p><?php esc_html_e( 'It\'s important to store your backups somewhere other than on your site. Using the extensions below you can easily push your backups to one or more Cloud providers.', 'backupwordpress' ); ?></p>
 
 	<div class="wp-list-table widefat plugin-install">
-
 		<div id="the-list">
 
 			<?php $first = true; ?>
@@ -55,29 +47,18 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 				?>
 
 				<div class="plugin-card plugin-card-<?php echo esc_attr( $extension->slug ); ?>">
-
 					<div class="plugin-card-top">
-
 						<div class="name column-name">
-
 							<h3>
-
 								<a href="<?php echo esc_url( $extension->link ); ?>" class="thickbox">
-
 									<?php echo esc_html( $extension->title->rendered ); ?>
-
-									<img src="<?php echo esc_url( $extension->featured_image_url ); ?>" class="plugin-icon" alt="">
-
+									<img src="<?php echo esc_url( $extension->featured_image_url ); ?>" class="plugin-icon" alt="" />
 								</a>
-
 							</h3>
-
 						</div>
 
 						<div class="action-links">
-
 							<ul class="plugin-action-buttons">
-
 								<li>
 									<?php
 									// Update Now - Installed and update is available.
@@ -124,9 +105,9 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 									) :
 
 										$activate_url = add_query_arg( array(
-											'_wpnonce'    => wp_create_nonce( 'activate-plugin_' . $installed_plugins[ $extension_name_lowcase ]['path'] ),
-											'action'      => 'activate',
-											'plugin'      => $installed_plugins[ $extension_name_lowcase ]['path'],
+											'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $installed_plugins[ $extension_name_lowcase ]['path'] ),
+											'action'   => 'activate',
+											'plugin'   => $installed_plugins[ $extension_name_lowcase ]['path'],
 											), network_admin_url( 'plugins.php' ) );
 
 										// TODO: Network Activate?
@@ -153,11 +134,9 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 										</a>
 
 									<?php endif; ?>
-
 								</li>
 
 								<li>
-
 									<a
 										href="<?php echo esc_url( $extension->link ); ?>"
 										class="thickbox"
@@ -165,19 +144,13 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 										data-title="<?php echo esc_attr( $extension->title->rendered ); ?>">
 										<?php esc_html_e( 'More Details', 'backupwordpress' ); ?>
 									</a>
-
 								</li>
-
 							</ul>
-
 						</div>
 
 						<div class="desc column-description">
-
 							<p><?php echo wp_kses_post( $extension->content->rendered ); ?></p>
-
 						</div>
-
 					</div>
 
 					<?php
@@ -186,12 +159,10 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 					?>
 
 					<div class="plugin-card-bottom" style="<?php echo esc_attr( $style ); ?>">
-
 						<div class="vers column-rating">
 						</div>
 
 						<div class="column-updated">
-
 							<?php printf(
 								wp_kses(
 									__( '<strong>Last Updated:</strong> %s ago', 'backupwordpress' ),
@@ -201,17 +172,11 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 								),
 								esc_html( human_time_diff( strtotime( $extension->modified ) ) )
 							); ?>
-
 						</div>
-
 					</div>
-
 				</div>
 
 			<?php endforeach; ?>
-
 		</div>
-
 	</div>
-
 </div>

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -25,8 +25,8 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	foreach ( get_plugins() as $path => $plugin_info ) {
 		$installed_plugins[ strtolower( $plugin_info['Name'] ) ] = array(
 			'version'   => $plugin_info['Version'],
-			'is_active' => is_plugin_active( $path ),
 			'path'      => $path,
+			'is_active' => is_plugin_active( $path ),
 		);
 	}
 	?>
@@ -44,6 +44,15 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 				$extension_name_lowcase = strtolower( $extension->title->rendered );
 				$is_extension_installed = in_array( $extension_name_lowcase, array_keys( $installed_plugins ) );
+
+				$extension_version  = $is_extension_installed ?
+					$installed_plugins[ $extension_name_lowcase ]['version'] : '';
+
+				$extension_path     = $is_extension_installed ?
+					$installed_plugins[ $extension_name_lowcase ]['path'] : '';
+
+				$is_extension_active = $is_extension_installed ?
+					$installed_plugins[ $extension_name_lowcase ]['is_active'] : false;
 				?>
 
 				<div class="plugin-card plugin-card-<?php echo esc_attr( $extension->slug ); ?>">
@@ -64,18 +73,18 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 									// Update Now - Installed and update is available.
 									if (
 										$is_extension_installed &&
-										version_compare( $installed_plugins[ $extension_name_lowcase ]['version'], $extension->_edd_sl_version, '<' )
+										version_compare( $extension_version, $extension->_edd_sl_version, '<' )
 									) :
 
 										$update_url = wp_nonce_url(
-											self_admin_url( 'update.php?action=upgrade-plugin&plugin=' . $installed_plugins[ $extension_name_lowcase ]['path'] ),
-											'upgrade-plugin_' . $installed_plugins[ $extension_name_lowcase ]['path']
+											self_admin_url( 'update.php?action=upgrade-plugin&plugin=' . $extension_path ),
+											'upgrade-plugin_' . $extension_path
 										);
 										?>
 
 										<a
 											class="update-now button aria-button-if-js"
-											data-plugin="<?php echo esc_attr( $installed_plugins[ $extension_name_lowcase ]['path'] ); ?>"
+											data-plugin="<?php echo esc_attr( $extension_path ); ?>"
 											data-slug="<?php echo esc_attr( $extension->slug ); ?>"
 											href="<?php echo esc_url( $update_url ); ?>"
 											aria-label="<?php echo esc_attr( sprintf( __( 'Update %s now', 'backupwordpress' ), $extension->title->rendered ) ) ?>"
@@ -85,10 +94,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 									<?php
 									// Active - Installed and activated, but no update.
-									elseif (
-										$is_extension_installed &&
-										$installed_plugins[ $extension_name_lowcase ]['is_active']
-									) : ?>
+									elseif ( $is_extension_installed && $is_extension_active ) : ?>
 
 										<button
 											type="button"
@@ -99,15 +105,12 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 									<?php
 									// Activate - Installed, but not activated.
-									elseif (
-										$is_extension_installed &&
-										! $installed_plugins[ $extension_name_lowcase ]['is_active']
-									) :
+									elseif ( $is_extension_installed && ! $is_extension_active ) :
 
 										$activate_url = add_query_arg( array(
-											'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $installed_plugins[ $extension_name_lowcase ]['path'] ),
+											'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $extension_path ),
 											'action'   => 'activate',
-											'plugin'   => $installed_plugins[ $extension_name_lowcase ]['path'],
+											'plugin'   => $extension_path,
 											), network_admin_url( 'plugins.php' ) );
 
 										// TODO: Network Activate?

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -131,7 +131,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 											class="install-now button-primary"
 											data-slug="<?php echo esc_attr( $extension->slug ); ?>"
 											href="<?php echo esc_url( $extension->link ); ?>"
-											aria-label="Install <?php echo esc_attr( $extension->title->rendered ); ?> now"
+											aria-label="<?php printf( esc_attr__( 'Install %s now', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>
 											data-name="<?php echo esc_attr( $extension->title->rendered ); ?>">
 											<?php printf( esc_html__( 'Buy Now &#36;%s', 'backupwordpress' ), esc_html( $extension->edd_price ) ); ?>
 										</a>

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -114,31 +114,37 @@ namespace HM\BackUpWordPress;
 
 							<div>
 
-								<?php esc_html_e( sprintf( __( 'Plugin version %s', 'backupwordpress' ), $extension->_edd_sl_version ) ); ?>
+								<?php esc_html_e( sprintf( __( 'Latest plugin version %s', 'backupwordpress' ), $extension->_edd_sl_version ) ); ?>
 
 							</div>
 
 							<div>
 
 								<?php
-
-								$text = '';
-
 								if ( in_array( strtolower( $extension->title->rendered ), array_keys( $installed_plugins ) ) ) {
 
 									$current_version = $installed_plugins[ strtolower( $extension->title->rendered ) ];
 
 									if ( version_compare( $current_version, $extension->_edd_sl_version, '<' ) ) {
 
-										$text = sprintf( __( 'A newer version (%1$s) is available. <a href="%2$s">Update now!</a>', 'backupwordpress' ), esc_html( $extension->_edd_sl_version ), esc_url( admin_url( 'update-core.php' ) ) );
+										printf(
+											wp_kses(
+												/* translators: 1: Currently installed extension version 2: URL to update an extension 3: Latest extension version */
+												__( 'Your installed plugin version %1$s <a href="%2$s">Update now to the latest version</a>.', 'backupwordpress' ),
+												array(
+													'a' => array(
+														'href' => array(),
+													),
+												)
+											),
+											esc_html( $current_version ),
+											esc_url( admin_url( 'update-core.php' ) )
+										);
 									} else {
 
-										$text = esc_html__( 'You have the latest version', 'backupwordpress' );
-
+										esc_html_e( 'You have the latest version', 'backupwordpress' );
 									}
 								}
-
-								echo $text;
 
 								?>
 

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -1,6 +1,5 @@
 <?php
 namespace HM\BackUpWordPress;
-include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 ?>
 
 <div class="wrap">
@@ -20,6 +19,14 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	usort( $extensions_data, function( $a, $b ) {
 		return strcmp( $b->title->rendered, $a->title->rendered );
 	});
+
+	/**
+	 * Include is required for the usage of is_plugin_active()
+	 * to identify if a plugin is currently activated.
+	 * This info is further used to display a correct action button
+	 * depending on plugin's state (i.e. Update Now, Activate, Active).
+	 */
+	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 	$installed_plugins = array();
 	foreach ( get_plugins() as $path => $plugin_info ) {

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -8,20 +8,20 @@ namespace HM\BackUpWordPress;
 
 	<h1>
 
-		<a class="page-title-action" href="<?php echo esc_url( get_settings_url() ); ?>"><?php _e( '&larr; Backups', 'backupwordpress' ); ?></a>
+		<a class="page-title-action" href="<?php echo esc_url( get_settings_url() ); ?>"><?php esc_html_e( '&larr; Backups', 'backupwordpress' ); ?></a>
 
-		<?php _e( 'BackUpWordPress Extensions', 'backupwordpress' ); ?>
+		<?php esc_html_e( 'BackUpWordPress Extensions', 'backupwordpress' ); ?>
 
 	</h1>
 
 	<div class="wp-filter">
-		<p><?php _e( 'Extend BackUpWordPress by installing extensions. Extensions allows you to pick and choose the exact features you need whilst also supporting us, the developers, so we can continue working on BackUpWordPress.', 'backupwordpress' ); ?></p>
+		<p><?php esc_html_e( 'Extend BackUpWordPress by installing extensions. Extensions allow you to pick and choose the exact features you need whilst also supporting us, the developers, so we can continue working on BackUpWordPress.', 'backupwordpress' ); ?></p>
 	</div>
 
 	<?php
 	$extensions_data = Extensions::get_instance()->get_edd_data();
 
-	// Sort by title
+	// Sort by title.
 	usort( $extensions_data, function( $a, $b ) {
 		return strcmp( $b->title->rendered, $a->title->rendered );
 	});
@@ -33,9 +33,9 @@ namespace HM\BackUpWordPress;
 
 	?>
 
-	<h3><?php _e( 'Remote Storage', 'backupwordpress' ); ?></h3>
+	<h3><?php esc_html_e( 'Remote Storage', 'backupwordpress' ); ?></h3>
 
-	<p><?php _e( 'It\'s important to store your backups somewhere other than on your site. Using the extensions below you can easily push your backups to one or more Cloud providers.', 'backupwordpress' ); ?></p>
+	<p><?php esc_html_e( 'It\'s important to store your backups somewhere other than on your site. Using the extensions below you can easily push your backups to one or more Cloud providers.', 'backupwordpress' ); ?></p>
 
 	<div class="wp-list-table widefat plugin-install">
 
@@ -72,11 +72,11 @@ namespace HM\BackUpWordPress;
 								<li>
 									<?php if ( in_array( strtolower( $extension->title->rendered ), array_keys( $installed_plugins ) ) ) : ?>
 
-										<span class="button button-disabled" title="<?php _e( 'This extension is already installed', 'backupwordpress' ); ?>"><?php _e( 'Installed', 'backupwordpress' ); ?></span>
+										<span class="button button-disabled" title="<?php esc_attr_e( 'This extension is already installed', 'backupwordpress' ); ?>"><?php esc_html_e( 'Installed', 'backupwordpress' ); ?></span>
 
 									<?php else : ?>
 
-										<a class="install-now button-primary" data-slug="<?php echo esc_attr( $extension->slug ); ?>" href="<?php echo esc_url( $extension->link ); ?>" aria-label="Install <?php echo esc_attr( $extension->title->rendered ); ?> now" data-name="<?php echo esc_attr( $extension->title->rendered ); ?>"><?php printf( __( 'Buy Now &dollar;%s', 'backupwordpress' ), $extension->edd_price ); ?></a>
+										<a class="install-now button-primary" data-slug="<?php echo esc_attr( $extension->slug ); ?>" href="<?php echo esc_url( $extension->link ); ?>" aria-label="Install <?php echo esc_attr( $extension->title->rendered ); ?> now" data-name="<?php echo esc_attr( $extension->title->rendered ); ?>"><?php printf( esc_html__( 'Buy Now &#36;%s', 'backupwordpress' ), esc_html( $extension->edd_price ) ); ?></a>
 
 									<?php endif; ?>
 
@@ -84,7 +84,7 @@ namespace HM\BackUpWordPress;
 
 								<li>
 
-									<a href="<?php echo esc_url( $extension->link ); ?>" class="thickbox" aria-label="<?php printf( __( 'More information about %s', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ) ; ?>" data-title="<?php echo esc_attr( $extension->title->rendered ); ?>"><?php _e( 'More Details', 'backupwordpress' ); ?></a>
+									<a href="<?php echo esc_url( $extension->link ); ?>" class="thickbox" aria-label="<?php printf( esc_attr__( 'More information about %s', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ) ; ?>" data-title="<?php echo esc_attr( $extension->title->rendered ); ?>"><?php esc_html_e( 'More Details', 'backupwordpress' ); ?></a>
 
 								</li>
 
@@ -114,7 +114,7 @@ namespace HM\BackUpWordPress;
 
 							<div>
 
-								<?php esc_html_e( sprintf( __( 'Latest plugin version %s', 'backupwordpress' ), $extension->_edd_sl_version ) ); ?>
+								<?php printf( esc_html__( 'Latest plugin version %s', 'backupwordpress' ), esc_html( $extension->_edd_sl_version ) ); ?>
 
 							</div>
 
@@ -154,7 +154,15 @@ namespace HM\BackUpWordPress;
 
 						<div class="column-updated">
 
-							<strong><?php _e( 'Last Updated:', 'backupwordpress' ); ?></strong> <span title="<?php echo esc_attr( $extension->modified ); ?>"><?php printf( __( '%s ago', 'backupwordpress' ), human_time_diff( strtotime( $extension->modified ) ) ); ?></span>
+							<?php printf(
+								wp_kses(
+									__( '<strong>Last Updated:</strong> %s ago', 'backupwordpress' ),
+									array(
+										'strong' => array(),
+									)
+								),
+								esc_html( human_time_diff( strtotime( $extension->modified ) ) )
+							); ?>
 
 						</div>
 

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -87,7 +87,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 											data-plugin="<?php echo esc_attr( $extension_path ); ?>"
 											data-slug="<?php echo esc_attr( $extension->slug ); ?>"
 											href="<?php echo esc_url( $update_url ); ?>"
-											aria-label="<?php echo esc_attr( sprintf( __( 'Update %s now', 'backupwordpress' ), $extension->title->rendered ) ) ?>"
+											aria-label="<?php printf( esc_attr__( 'Update %s now', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>"
 											data-name="<?php esc_attr( $extension->title->rendered ); ?>">
 											<?php esc_html_e( 'Update Now', 'backupwordpress' ); ?>
 										</a>
@@ -119,7 +119,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 										<a
 											href="<?php echo esc_url( $activate_url ); ?>"
 											class="button activate-now button-secondary"
-											aria-label="<?php esc_attr( sprintf( __( 'Activate %s', 'backupwordpress' ), $extension->title->rendered ) ); ?>">
+											aria-label="<?php printf( esc_attr__( 'Activate %s', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>">
 											<?php esc_html_e( 'Activate', 'backupwordpress' ); ?>
 										</a>
 

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -68,76 +68,85 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 						<div class="action-links">
 							<ul class="plugin-action-buttons">
-								<li>
-									<?php
-									// Update Now - Installed and update is available.
-									if (
-										$is_extension_installed &&
-										version_compare( $extension_version, $extension->_edd_sl_version, '<' )
-									) :
 
-										$update_url = wp_nonce_url(
-											self_admin_url( 'update.php?action=upgrade-plugin&plugin=' . $extension_path ),
-											'upgrade-plugin_' . $extension_path
-										);
-										?>
+								<?php
+								if (
+									current_user_can( 'install_plugins' ) ||
+									current_user_can( 'update_plugins' )
+								) : ?>
 
-										<a
-											class="update-now button aria-button-if-js"
-											data-plugin="<?php echo esc_attr( $extension_path ); ?>"
-											data-slug="<?php echo esc_attr( $extension->slug ); ?>"
-											href="<?php echo esc_url( $update_url ); ?>"
-											aria-label="<?php printf( esc_attr__( 'Update %s now', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>"
-											data-name="<?php esc_attr( $extension->title->rendered ); ?>">
-											<?php esc_html_e( 'Update Now', 'backupwordpress' ); ?>
-										</a>
+									<li>
+										<?php
+										// Update Now - Installed and update is available.
+										if (
+											$is_extension_installed &&
+											version_compare( $extension_version, $extension->_edd_sl_version, '<' )
+										) :
 
-									<?php
-									// Active - Installed and activated, but no update.
-									elseif ( $is_extension_installed && $is_extension_active ) : ?>
+											$update_url = wp_nonce_url(
+												self_admin_url( 'update.php?action=upgrade-plugin&plugin=' . $extension_path ),
+												'upgrade-plugin_' . $extension_path
+											);
+											?>
 
-										<button
-											type="button"
-											class="button button-disabled"
-											disabled="disabled">
-											<?php echo esc_html_x( 'Active', 'Plugin status', 'backupwordpress' ); ?>
-										</button>
+											<a
+												class="update-now button aria-button-if-js"
+												data-plugin="<?php echo esc_attr( $extension_path ); ?>"
+												data-slug="<?php echo esc_attr( $extension->slug ); ?>"
+												href="<?php echo esc_url( $update_url ); ?>"
+												aria-label="<?php printf( esc_attr__( 'Update %s now', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>"
+												data-name="<?php esc_attr( $extension->title->rendered ); ?>">
+												<?php esc_html_e( 'Update Now', 'backupwordpress' ); ?>
+											</a>
 
-									<?php
-									// Activate - Installed, but not activated.
-									elseif ( $is_extension_installed && ! $is_extension_active ) :
+										<?php
+										// Active - Installed and activated, but no update.
+										elseif ( $is_extension_installed && $is_extension_active ) : ?>
 
-										$activate_url = add_query_arg( array(
-											'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $extension_path ),
-											'action'   => 'activate',
-											'plugin'   => $extension_path,
-											), network_admin_url( 'plugins.php' ) );
+											<button
+												type="button"
+												class="button button-disabled"
+												disabled="disabled">
+												<?php echo esc_html_x( 'Active', 'Plugin status', 'backupwordpress' ); ?>
+											</button>
 
-										// TODO: Network Activate?
-										?>
+										<?php
+										// Activate - Installed, but not activated.
+										elseif ( $is_extension_installed && ! $is_extension_active ) :
 
-										<a
-											href="<?php echo esc_url( $activate_url ); ?>"
-											class="button activate-now button-secondary"
-											aria-label="<?php printf( esc_attr__( 'Activate %s', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>">
-											<?php esc_html_e( 'Activate', 'backupwordpress' ); ?>
-										</a>
+											$activate_url = add_query_arg( array(
+												'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $extension_path ),
+												'action'   => 'activate',
+												'plugin'   => $extension_path,
+												), network_admin_url( 'plugins.php' ) );
 
-									<?php
-									// Buy Now - Not installed.
-									else : ?>
+											// TODO: Network Activate?
+											?>
 
-										<a
-											class="install-now button-primary"
-											data-slug="<?php echo esc_attr( $extension->slug ); ?>"
-											href="<?php echo esc_url( $extension->link ); ?>"
-											aria-label="<?php printf( esc_attr__( 'Install %s now', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>
-											data-name="<?php echo esc_attr( $extension->title->rendered ); ?>">
-											<?php printf( esc_html__( 'Buy Now &#36;%s', 'backupwordpress' ), esc_html( $extension->edd_price ) ); ?>
-										</a>
+											<a
+												href="<?php echo esc_url( $activate_url ); ?>"
+												class="button activate-now button-secondary"
+												aria-label="<?php printf( esc_attr__( 'Activate %s', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>">
+												<?php esc_html_e( 'Activate', 'backupwordpress' ); ?>
+											</a>
 
-									<?php endif; ?>
-								</li>
+										<?php
+										// Buy Now - Not installed.
+										else : ?>
+
+											<a
+												class="install-now button-primary"
+												data-slug="<?php echo esc_attr( $extension->slug ); ?>"
+												href="<?php echo esc_url( $extension->link ); ?>"
+												aria-label="<?php printf( esc_attr__( 'Install %s now', 'backupwordpress' ), esc_attr( $extension->title->rendered ) ); ?>
+												data-name="<?php echo esc_attr( $extension->title->rendered ); ?>">
+												<?php printf( esc_html__( 'Buy Now &#36;%s', 'backupwordpress' ), esc_html( $extension->edd_price ) ); ?>
+											</a>
+
+										<?php endif; ?>
+									</li>
+
+								<?php endif; ?>
 
 								<li>
 									<a


### PR DESCRIPTION
Fixes #1098 

**TODO**
- [x] Fix Windows Azure icon
- [x] Disable `Update Now` button on Extensions page when no/expired licence. Add note that update needs a valid licence. (**NB** it might be good to add a note to Plugins WP admin page - to notify user and provide a choice to get a licence). **NB**: Added separate issue for this: https://github.com/humanmade/backupwordpress/issues/1130