### PR TITLE
Remove disk_space_low check from is_backup_possible

### DIFF
--- a/functions/core.php
+++ b/functions/core.php
@@ -411,10 +411,6 @@ function is_backup_possible() {
 		return false;
 	}
 
-	if ( disk_space_low() ) {
-		return false;
-	}
-
 	if ( ! Requirement_Mysqldump_Command_Path::test() && ! Requirement_PDO::test() ) {
 		return false;
 	}


### PR DESCRIPTION
Stops low disk space blocking users from accessing BWP settings.

Fixes https://github.com/humanmade/backupwordpress/issues/1131