### PR TITLE
#1030 Remove admin block

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -15,9 +15,12 @@ namespace HM\BackUpWordPress;
 		<?php if ( get_option( 'hmbkp_enable_support' ) ) : ?>
 
 			<a id="intercom" class="page-title-action" href="mailto:backupwordpress@hmn.md"><?php _e( 'Support', 'backupwordpress' ); ?></a>
+
 		<?php else :
+
 			add_thickbox(); ?>
 			<a id="intercom-info" class="thickbox page-title-action" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'load_enable_support', 'width' => '600', 'height' => '420' ), self_admin_url( 'admin-ajax.php' ) ), 'hmbkp_nonce' ) ); ?>"><span class="dashicons dashicons-admin-users"></span>&nbsp;<?php _e( 'Enable Support', 'backupwordpress' ); ?></a>
+
 		<?php endif; ?>
 
 	</h1>

--- a/admin/page.php
+++ b/admin/page.php
@@ -22,14 +22,10 @@ namespace HM\BackUpWordPress;
 
 	</h1>
 
-	<?php if ( is_backup_possible() ) : ?>
+	<?php include_once( HMBKP_PLUGIN_PATH . 'admin/backups.php' ); ?>
 
-		<?php include_once( HMBKP_PLUGIN_PATH . 'admin/backups.php' ); ?>
+	<p class="howto"><?php printf( __( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory%2$s.', 'backupwordpress' ), '<a target="_blank" href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">', '</a>' ); ?></p>
 
-		<p class="howto"><?php printf( __( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory%2$s.', 'backupwordpress' ), '<a target="_blank" href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">', '</a>' ); ?></p>
-
-		<?php include_once( HMBKP_PLUGIN_PATH . 'admin/upsell.php' ); ?>
-
-	<?php endif; ?>
+	<?php include_once( HMBKP_PLUGIN_PATH . 'admin/upsell.php' ); ?>
 
 </div>

--- a/admin/schedule-settings.php
+++ b/admin/schedule-settings.php
@@ -6,7 +6,11 @@ if ( Schedules::get_instance()->get_schedule( $schedule->get_id() ) ) { ?>
 
 	<div class="hmbkp-schedule-actions row-actions">
 
-		<a class="hmbkp-run" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'hmbkp_run_schedule', 'hmbkp_schedule_id' => $schedule->get_id() ), admin_url( 'admin-ajax.php' ) ), 'hmbkp_run_schedule', 'hmbkp_run_schedule_nonce' ) ); ?>"><?php _e( 'Run now', 'backupwordpress' ); ?></a>  |
+		<?php if ( is_backup_possible() ) : ?>
+
+			<a class="hmbkp-run" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'hmbkp_run_schedule', 'hmbkp_schedule_id' => $schedule->get_id() ), admin_url( 'admin-ajax.php' ) ), 'hmbkp_run_schedule', 'hmbkp_run_schedule_nonce' ) ); ?>"><?php _e( 'Run now', 'backupwordpress' ); ?></a>  |
+
+		<?php endif; ?>
 
 		<a href="<?php echo esc_url( add_query_arg( array( 'action' => 'hmbkp_edit_schedule', 'hmbkp_panel' => 'hmbkp_edit_schedule_settings', 'hmbkp_schedule_id' => $schedule->get_id() ), get_settings_url() ), 'hmbkp-edit-schedule' ); ?>"><?php _e( 'Settings', 'backupwordpress' ); ?></a> |
 

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -450,7 +450,7 @@ function disk_space_low( $backup_size = false ) {
 
 	if ( ! $backup_size ) {
 
-		$site_size = new Site_Size( 'complete', new Excludes );
+		$site_size = new Site_Size();
 
 		if ( ! $site_size->is_site_size_cached() ) {
 			return false;

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -450,7 +450,7 @@ function disk_space_low( $backup_size = false ) {
 
 	if ( ! $backup_size ) {
 
-		$site_size = new Site_Size();
+		$site_size = new Site_Size( 'complete', new Excludes );
 
 		if ( ! $site_size->is_site_size_cached() ) {
 			return false;


### PR DESCRIPTION
Remove the check around the admin interface that blocks access if a backup isn't possible. Apply the check instead to the button for triggering a manual backup.

Addresses https://github.com/humanmade/backupwordpress/issues/1030