### PR TITLE
#1063 Account for excludes when calculating if disk space is too low

### DIFF
--- a/functions/interface.php
+++ b/functions/interface.php
@@ -450,7 +450,7 @@ function disk_space_low( $backup_size = false ) {
 
 	if ( ! $backup_size ) {
 
-		$site_size = new Site_Size( 'complete', new Excludes );
+		$site_size = new Site_Size( 'complete', new Excludes() );
 
 		if ( ! $site_size->is_site_size_cached() ) {
 			return false;

--- a/functions/interface.php
+++ b/functions/interface.php
@@ -450,7 +450,7 @@ function disk_space_low( $backup_size = false ) {
 
 	if ( ! $backup_size ) {
 
-		$site_size = new Site_Size();
+		$site_size = new Site_Size( 'complete', new Excludes );
 
 		if ( ! $site_size->is_site_size_cached() ) {
 			return false;


### PR DESCRIPTION
Pass `Excludes` when calculating the site size in `disk_space_low()` function to give a more accurate response.

Previously, `disk_space_low()` would return true if the entire site (including previous backups) was too big to be backed up, not just the files specified to be backed up.

Addresses https://github.com/humanmade/backupwordpress/issues/1063