### PR TITLE
#1125 Highlight the 'Backups' submenu item when on the Extentions page

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -42,6 +42,28 @@ function extensions() {
 }
 
 /**
+ * Highlights the 'Backups' submenu item when on the Extentions page
+ *
+ * @param string $parent_file The filename of the parent menu item
+ * @return string $parent_file The filename of the parent menu item
+ */
+function highlight_submenu( $parent_file ) {
+
+	global $submenu_file;
+
+	$screen = get_current_screen();
+
+	if ( 'tools_page_' . HMBKP_PLUGIN_SLUG . '_extensions' === $screen->id ) {
+
+		$submenu_file = HMBKP_PLUGIN_SLUG;
+
+	}
+
+	return $parent_file;
+}
+add_filter( 'parent_file', 'HM\BackUpWordPress\highlight_submenu' );
+
+/**
  * Add a link to the backups page to the plugin action links.
  *
  * @param array $links

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -44,12 +44,10 @@ function extensions() {
 /**
  * Highlights the 'Backups' submenu item when on the Extentions page
  *
- * @param string $parent_file The filename of the parent menu item
- * @return string $parent_file The filename of the parent menu item
+ * @param string $submenu_file
+ * @return string $submenu_file The slug of the menu item to highlight
  */
-function highlight_submenu( $parent_file ) {
-
-	global $submenu_file;
+function highlight_submenu( $submenu_file ) {
 
 	$screen = get_current_screen();
 
@@ -60,9 +58,10 @@ function highlight_submenu( $parent_file ) {
 
 	}
 
-	return $parent_file;
+	return $submenu_file;
+
 }
-add_filter( 'parent_file', 'HM\BackUpWordPress\highlight_submenu' );
+add_filter( 'submenu_file', 'HM\BackUpWordPress\highlight_submenu' );
 
 /**
  * Add a link to the backups page to the plugin action links.

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -42,7 +42,7 @@ function extensions() {
 }
 
 /**
- * Highlights the 'Backups' submenu item when on the Extentions page
+ * Highlights the 'Backups' submenu item when on the Extensions page
  *
  * @param string $submenu_file
  * @return string $submenu_file The slug of the menu item to highlight

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -55,6 +55,7 @@ function highlight_submenu( $parent_file ) {
 
 	if ( 'tools_page_' . HMBKP_PLUGIN_SLUG . '_extensions' === $screen->id ) {
 
+		// Set the main plugin page to be the active submenu page
 		$submenu_file = HMBKP_PLUGIN_SLUG;
 
 	}


### PR DESCRIPTION
Forces the main BWP 'Backups' page to be highlighted in the admin sidebar when visiting the 'Extensions' page. 

Achieved by setting the main 'Backups' page to be the current subpage when on the 'Extensions' page via the `parent_file` hook.

Addresses #1125.