### PR TITLE
Ensure only new persistant notices are added added to the database

### DIFF
--- a/classes/class-notices.php
+++ b/classes/class-notices.php
@@ -84,9 +84,9 @@ class Notices {
 
 			$new_notices = $notices = $this->get_persistent_notices();
 
-			// Make sure we merge in any existing notices
+			// Make sure we merge new notices into to any existing notices
 			if ( ! empty( $notices[ $context ] ) ) {
-				$new_notices[ $context ] = array_merge( $notices[ $context ], $messages );
+				$new_notices[ $context ] = array_unique( array_merge( $new_notices[ $context ], $messages ) );
 			} else {
 				$new_notices[ $context ] = $messages;
 			}


### PR DESCRIPTION
Previously, any new admin notices were merged into the array of persistent notices in the database without checking if the new notice already existed as a persistent notice, causing the database to fill up with multiple instances of the same message. This wasn't seen in the admin because array_unique is used before outputting each notice.