### PR TITLE
Fix wp-snapshots

### DIFF
--- a/classes/class-excludes.php
+++ b/classes/class-excludes.php
@@ -32,7 +32,7 @@ class Excludes {
 		'backupwp',
 		'backwpup-*',
 		'updraft',
-		'(?:wp-)?snapshots?', // wp-snapshots, snapshots, snapshot
+		'wp-snapshots',
 		'backupbuddy_backups',
 		'pb_backupbuddy',
 		'backup-db',


### PR DESCRIPTION
This wildcard set is causing wp-snapshots to NOT be excluded per report from user in forum. I confirmed this on my test site, and changed the plugin back to the previous iteration which was just using 'wp-snapshots' - and that worked perfectly. Unsure exactly why this happened but pretty sure the wildcard specification needs further translating for regex to do it correctly?