### PR TITLE
Change extension links for BWP

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -10,7 +10,7 @@ namespace HM\BackUpWordPress;
 
 		BackUpWordPress
 
-		<a class="page-title-action" href="<?php echo esc_url( get_settings_url( HMBKP_PLUGIN_SLUG . '_extensions' ) ); ?>">Extensions</a>
+		<a class="page-title-action" href="<?php echo esc_url( https://bwp.hmn.md/ ); ?>" target="_blank">Extensions</a>
 
 		<?php if ( get_option( 'hmbkp_enable_support' ) ) : ?>
 

--- a/admin/upsell.php
+++ b/admin/upsell.php
@@ -7,7 +7,7 @@
 /** translators:  the 1st placeholder is the first part of the anchor tag with the link to the extensions admin page and the second is the closing anchor tag */
 printf(
 	__( 'Store your backups securely in the Cloud with %1$sour extensions%2$s', 'backupwordpress' ),
-    '<a href="https://bwp.hmn.md/" target="_blank">',
+    '<a href="<?php echo esc_url( https://bwp.hmn.md/ ); ?>" target="_blank">',
     '</a>'
 );
 ?>

--- a/admin/upsell.php
+++ b/admin/upsell.php
@@ -7,8 +7,8 @@
 /** translators:  the 1st placeholder is the first part of the anchor tag with the link to the extensions admin page and the second is the closing anchor tag */
 printf(
 	__( 'Store your backups securely in the Cloud with %1$sour extensions%2$s', 'backupwordpress' ),
-	'<a href="' . esc_url( get_settings_url( HMBKP_PLUGIN_SLUG . '_extensions' ) ) . '">',
-	'</a>'
+    '<a href="https://bwp.hmn.md/" target="_blank">',
+    '</a>'
 );
 ?>
 

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -443,7 +443,7 @@ final class Plugin {
 		/* translators: %1$s and %2$s expand to anchor tags linking to the new extensions page. */
 		$info_message = sprintf(
 			__( 'Thanks for updating BackUpWordPress, why not check out %1$sour extensions?%2$s', 'backupwordpress' ),
-			'<a href="' . esc_url( get_settings_url( HMBKP_PLUGIN_SLUG . '_extensions' ) ) . '">',
+			'<a href="<?php echo esc_url( https://bwp.hmn.md/ ); ?>" target="_blank">',
 			'</a>'
 		);
 		?>


### PR DESCRIPTION
This changes the extension links in three places to link back to the website instead of to the extensions page. Per meeting and workshop with Products team, we want to focus on improving the funnel onsite before we re-integrate the extensions page onsite and work on purchasing ability from there. 

Should the actual extensions page be pulled out to it's own PR, ie. removed from current code and re-added via a PR so we can work on completing the full extension page updates and potentially adding in purchase links? Let's ask @pdewouters for feedback here if he has a moment? 

As for reviewing the commits - I'm still shaky on when to escape and whether I did that correctly, so would like to have conversation regarding that ;-) 