### PR TITLE
Update to error notices. Removed extra extensions upsell and replaced…

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -10,7 +10,7 @@ namespace HM\BackUpWordPress;
 
 		BackUpWordPress
 
-		<a class="page-title-action" href="<?php echo esc_url( https://bwp.hmn.md/ ); ?>" target="_blank">Extensions</a>
+        <a class="page-title-action" href="<?php echo esc_url( 'https://bwp.hmn.md/' ); ?>" target="_blank">Extensions</a>
 
 		<?php if ( get_option( 'hmbkp_enable_support' ) ) : ?>
 
@@ -28,9 +28,7 @@ namespace HM\BackUpWordPress;
 	<?php if ( has_server_permissions() ) : ?>
 
 		<?php include_once( HMBKP_PLUGIN_PATH . 'admin/backups.php' ); ?>
-
-		<p class="howto"><?php printf( __( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory%2$s.', 'backupwordpress' ), '<a target="_blank" href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">', '</a>' ); ?></p>
-
+  
 		<?php include_once( HMBKP_PLUGIN_PATH . 'admin/upsell.php' ); ?>
 
 	<?php else : ?>

--- a/admin/page.php
+++ b/admin/page.php
@@ -10,7 +10,7 @@ namespace HM\BackUpWordPress;
 
 		BackUpWordPress
 
-        <a class="page-title-action" href="<?php echo esc_url( 'https://bwp.hmn.md/' ); ?>" target="_blank">Extensions</a>
+        <a class="page-title-action" href="https://bwp.hmn.md/" target="_blank">Extensions</a>
 
 		<?php if ( get_option( 'hmbkp_enable_support' ) ) : ?>
 

--- a/admin/upsell.php
+++ b/admin/upsell.php
@@ -3,7 +3,7 @@
 
 <?php
 /** translators:  the 1st placeholder is the first part of the anchor tag with the link to the plugin review page and the second is the closing anchor tag */
-$cta_message = printf(
+$cta_message = sprintf(
 	__( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory%2$s.', 'backupwordpress' ),
 	'<a target="_blank" href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">',
 	'</a>'

--- a/admin/upsell.php
+++ b/admin/upsell.php
@@ -1,17 +1,17 @@
 <?php namespace HM\BackUpWordPress; ?>
 <div class="hmbkp-upsell">
 
-<p>
-
 <?php
-/** translators:  the 1st placeholder is the first part of the anchor tag with the link to the extensions admin page and the second is the closing anchor tag */
-printf(
-	__( 'Store your backups securely in the Cloud with %1$sour extensions%2$s', 'backupwordpress' ),
-    '<a href="<?php echo esc_url( https://bwp.hmn.md/ ); ?>" target="_blank">',
-    '</a>'
+/** translators:  the 1st placeholder is the first part of the anchor tag with the link to the plugin review page and the second is the closing anchor tag */
+$cta_message = printf(
+	__( 'If you\'re finding BackUpWordPress useful, please %1$s rate it on the plugin directory%2$s.', 'backupwordpress' ),
+	'<a target="_blank" href="http://wordpress.org/support/view/plugin-reviews/backupwordpress">',
+	'</a>'
 );
 ?>
-
-</p>
+    <div id="hmbkp-cta-message" class="updated notice is-dismissible">
+    <p><?php echo wp_kses_post( $cta_message ); ?></p>
+    <button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'backupwordpress' ); ?></span></button>
+</div>
 
 </div>

--- a/admin/upsell.php
+++ b/admin/upsell.php
@@ -9,7 +9,7 @@ $cta_message = sprintf(
 	'</a>'
 );
 ?>
-    <div id="hmbkp-cta-message" class="updated notice is-dismissible">
+<div id="hmbkp-cta-message" class="updated notice is-dismissible">
     <p><?php echo wp_kses_post( $cta_message ); ?></p>
     <button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'backupwordpress' ); ?></span></button>
 </div>


### PR DESCRIPTION
… non-dismissible notice with a dismissible notice. Both are at the top, though? @mikeselander you were the one who noticed this previously. My only concern at this point is that both main notices are at the top of the page (the extension one and the rate us one), rather than one at the top and two at the bottom. 

I'm not positive whether having both at the top is desireable. See image: 
<img width="1105" alt="screen shot 2017-05-11 at 11 55 19 am" src="https://cloud.githubusercontent.com/assets/5481211/25959135/c58d1c22-3640-11e7-8141-8cb3f6bdc1c2.png">
