### PR TITLE
Fix PHP deprecation warnings

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -14,7 +14,7 @@ function admin_menu() {
 		add_management_page( __( 'Manage Backups', 'backupwordpress' ), __( 'Backups', 'backupwordpress' ), ( defined( 'HMBKP_CAPABILITY' ) && HMBKP_CAPABILITY ) ? HMBKP_CAPABILITY : 'manage_options', HMBKP_PLUGIN_SLUG, 'HM\BackUpWordPress\manage_backups' );
 	}
 
-	add_submenu_page( null, __( 'BackUpWordPress Extensions', 'backupwordpress' ), __( 'Extensions', 'backupwordpress' ), ( defined( 'HMBKP_CAPABILITY' ) && HMBKP_CAPABILITY ) ? HMBKP_CAPABILITY : 'manage_options', HMBKP_PLUGIN_SLUG . '_extensions', 'HM\BackUpWordPress\extensions' );
+	add_submenu_page('options.php', __( 'BackUpWordPress Extensions', 'backupwordpress' ), __( 'Extensions', 'backupwordpress' ), ( defined( 'HMBKP_CAPABILITY' ) && HMBKP_CAPABILITY ) ? HMBKP_CAPABILITY : 'manage_options', HMBKP_PLUGIN_SLUG . '_extensions', 'HM\BackUpWordPress\extensions' );
 
 }
 add_action( 'network_admin_menu', 'HM\BackUpWordPress\admin_menu' );

--- a/classes/class-path.php
+++ b/classes/class-path.php
@@ -452,7 +452,7 @@ class Path {
 class CleanUpIterator extends \FilterIterator {
 
 	// Don't match index.html, files with zip extension or status logfiles.
-	public function accept() {
+	public function accept(): bool {
 
 		// Don't remove existing backups
 		if ( 'zip' === pathinfo( $this->current()->getFilename(), PATHINFO_EXTENSION ) ) {

--- a/classes/class-scheduled-backup.php
+++ b/classes/class-scheduled-backup.php
@@ -28,6 +28,15 @@ class Scheduled_Backup {
 	 */
 	private $slug = '';
 
+	/** @var string|null */
+	private $backup_filename = NULL;
+
+	/** @var string|null */
+	private $database_dump_filename = NULL;
+
+	/** @var Backup_Status|null */
+	private $status = NULL;
+
 	/**
 	 * The raw schedule options from the database
 	 *


### PR DESCRIPTION
With PHP 8.1, I get some deprecation warnings:

>  Deprecated: Return type of HM\BackUpWordPress\CleanUpIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../wp-content/plugins/backupwordpress/classes/class-path.php on line 456
> 
> Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /.../wp-includes/functions.php on line 7241
> 
> Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /.../wp-includes/functions.php on line 2187
> 
> Deprecated: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /.../wp-admin/admin-header.php on line 36

It turned out that they were quite easy to fix. The extensions menu page is still broken, though, which is caused by the unreachable API.